### PR TITLE
Release version 0.1.5 dist fixes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -267,7 +267,7 @@ checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
 name = "conclaude"
-version = "0.1.3"
+version = "0.1.5"
 dependencies = [
  "anyhow",
  "chrono",

--- a/dist-workspace.toml
+++ b/dist-workspace.toml
@@ -10,7 +10,7 @@ ci = "github"
 # The installers to generate for each app
 installers = ["shell", "powershell", "npm", "msi"]
 # Target platforms to build apps for (Rust target-triple syntax)
-targets = ["aarch64-apple-darwin", "aarch64-unknown-linux-gnu", "aarch64-pc-windows-msvc", "x86_64-apple-darwin", "x86_64-unknown-linux-gnu", "x86_64-unknown-linux-musl", "x86_64-pc-windows-msvc"]
+targets = ["aarch64-apple-darwin", "aarch64-unknown-linux-gnu", "x86_64-apple-darwin", "x86_64-unknown-linux-gnu", "x86_64-unknown-linux-musl", "x86_64-pc-windows-msvc"]
 # Path that installers should place binaries in
 install-path = "CARGO_HOME"
 # Whether to install an updater program

--- a/plan-dist-manifest.json
+++ b/plan-dist-manifest.json
@@ -1,0 +1,600 @@
+{
+  "dist_version": "0.29.0",
+  "announcement_tag": "v0.1.5",
+  "announcement_tag_is_implicit": false,
+  "announcement_is_prerelease": false,
+  "announcement_title": "v0.1.5",
+  "announcement_github_body": "## Install conclaude 0.1.5\n\n### Install prebuilt binaries via shell script\n\n```sh\ncurl --proto '=https' --tlsv1.2 -LsSf https://github.com/connix-io/conclaude/releases/download/v0.1.5/conclaude-installer.sh | sh\n```\n\n### Install prebuilt binaries via powershell script\n\n```sh\npowershell -ExecutionPolicy Bypass -c \"irm https://github.com/connix-io/conclaude/releases/download/v0.1.5/conclaude-installer.ps1 | iex\"\n```\n\n### Install prebuilt binaries into your npm project\n\n```sh\nnpm install conclaude@0.1.5\n```\n\n## Download conclaude 0.1.5\n\n|  File  | Platform | Checksum |\n|--------|----------|----------|\n| [conclaude-aarch64-apple-darwin.tar.xz](https://github.com/connix-io/conclaude/releases/download/v0.1.5/conclaude-aarch64-apple-darwin.tar.xz) | Apple Silicon macOS | [checksum](https://github.com/connix-io/conclaude/releases/download/v0.1.5/conclaude-aarch64-apple-darwin.tar.xz.sha256) |\n| [conclaude-x86_64-apple-darwin.tar.xz](https://github.com/connix-io/conclaude/releases/download/v0.1.5/conclaude-x86_64-apple-darwin.tar.xz) | Intel macOS | [checksum](https://github.com/connix-io/conclaude/releases/download/v0.1.5/conclaude-x86_64-apple-darwin.tar.xz.sha256) |\n| [conclaude-aarch64-pc-windows-msvc.zip](https://github.com/connix-io/conclaude/releases/download/v0.1.5/conclaude-aarch64-pc-windows-msvc.zip) | ARM64 Windows | [checksum](https://github.com/connix-io/conclaude/releases/download/v0.1.5/conclaude-aarch64-pc-windows-msvc.zip.sha256) |\n| [conclaude-aarch64-pc-windows-msvc.msi](https://github.com/connix-io/conclaude/releases/download/v0.1.5/conclaude-aarch64-pc-windows-msvc.msi) | ARM64 Windows | [checksum](https://github.com/connix-io/conclaude/releases/download/v0.1.5/conclaude-aarch64-pc-windows-msvc.msi.sha256) |\n| [conclaude-x86_64-pc-windows-msvc.zip](https://github.com/connix-io/conclaude/releases/download/v0.1.5/conclaude-x86_64-pc-windows-msvc.zip) | x64 Windows | [checksum](https://github.com/connix-io/conclaude/releases/download/v0.1.5/conclaude-x86_64-pc-windows-msvc.zip.sha256) |\n| [conclaude-x86_64-pc-windows-msvc.msi](https://github.com/connix-io/conclaude/releases/download/v0.1.5/conclaude-x86_64-pc-windows-msvc.msi) | x64 Windows | [checksum](https://github.com/connix-io/conclaude/releases/download/v0.1.5/conclaude-x86_64-pc-windows-msvc.msi.sha256) |\n| [conclaude-aarch64-unknown-linux-gnu.tar.xz](https://github.com/connix-io/conclaude/releases/download/v0.1.5/conclaude-aarch64-unknown-linux-gnu.tar.xz) | ARM64 Linux | [checksum](https://github.com/connix-io/conclaude/releases/download/v0.1.5/conclaude-aarch64-unknown-linux-gnu.tar.xz.sha256) |\n| [conclaude-x86_64-unknown-linux-gnu.tar.xz](https://github.com/connix-io/conclaude/releases/download/v0.1.5/conclaude-x86_64-unknown-linux-gnu.tar.xz) | x64 Linux | [checksum](https://github.com/connix-io/conclaude/releases/download/v0.1.5/conclaude-x86_64-unknown-linux-gnu.tar.xz.sha256) |\n| [conclaude-x86_64-unknown-linux-musl.tar.xz](https://github.com/connix-io/conclaude/releases/download/v0.1.5/conclaude-x86_64-unknown-linux-musl.tar.xz) | x64 MUSL Linux | [checksum](https://github.com/connix-io/conclaude/releases/download/v0.1.5/conclaude-x86_64-unknown-linux-musl.tar.xz.sha256) |\n\n",
+  "releases": [
+    {
+      "app_name": "conclaude",
+      "app_version": "0.1.5",
+      "env": {
+        "install_dir_env_var": "CONCLAUDE_INSTALL_DIR",
+        "unmanaged_dir_env_var": "CONCLAUDE_UNMANAGED_INSTALL",
+        "disable_update_env_var": "CONCLAUDE_DISABLE_UPDATE",
+        "no_modify_path_env_var": "CONCLAUDE_NO_MODIFY_PATH",
+        "github_base_url_env_var": "CONCLAUDE_INSTALLER_GITHUB_BASE_URL",
+        "ghe_base_url_env_var": "CONCLAUDE_INSTALLER_GHE_BASE_URL",
+        "github_token_env_var": "CONCLAUDE_GITHUB_TOKEN"
+      },
+      "display_name": "conclaude",
+      "display": true,
+      "artifacts": [
+        "source.tar.gz",
+        "source.tar.gz.sha256",
+        "conclaude-installer.sh",
+        "conclaude-installer.ps1",
+        "conclaude-npm-package.tar.gz",
+        "sha256.sum",
+        "conclaude-aarch64-apple-darwin-update",
+        "conclaude-aarch64-apple-darwin.tar.xz",
+        "conclaude-aarch64-apple-darwin.tar.xz.sha256",
+        "conclaude-aarch64-pc-windows-msvc-update",
+        "conclaude-aarch64-pc-windows-msvc.zip",
+        "conclaude-aarch64-pc-windows-msvc.zip.sha256",
+        "conclaude-aarch64-pc-windows-msvc.msi",
+        "conclaude-aarch64-pc-windows-msvc.msi.sha256",
+        "conclaude-aarch64-unknown-linux-gnu-update",
+        "conclaude-aarch64-unknown-linux-gnu.tar.xz",
+        "conclaude-aarch64-unknown-linux-gnu.tar.xz.sha256",
+        "conclaude-x86_64-apple-darwin-update",
+        "conclaude-x86_64-apple-darwin.tar.xz",
+        "conclaude-x86_64-apple-darwin.tar.xz.sha256",
+        "conclaude-x86_64-pc-windows-msvc-update",
+        "conclaude-x86_64-pc-windows-msvc.zip",
+        "conclaude-x86_64-pc-windows-msvc.zip.sha256",
+        "conclaude-x86_64-pc-windows-msvc.msi",
+        "conclaude-x86_64-pc-windows-msvc.msi.sha256",
+        "conclaude-x86_64-unknown-linux-gnu-update",
+        "conclaude-x86_64-unknown-linux-gnu.tar.xz",
+        "conclaude-x86_64-unknown-linux-gnu.tar.xz.sha256",
+        "conclaude-x86_64-unknown-linux-musl-update",
+        "conclaude-x86_64-unknown-linux-musl.tar.xz",
+        "conclaude-x86_64-unknown-linux-musl.tar.xz.sha256"
+      ],
+      "hosting": {
+        "github": {
+          "artifact_base_url": "https://github.com",
+          "artifact_download_path": "/connix-io/conclaude/releases/download/v0.1.5",
+          "owner": "connix-io",
+          "repo": "conclaude"
+        }
+      }
+    }
+  ],
+  "artifacts": {
+    "conclaude-aarch64-apple-darwin-update": {
+      "name": "conclaude-aarch64-apple-darwin-update",
+      "kind": "updater",
+      "target_triples": [
+        "aarch64-apple-darwin"
+      ]
+    },
+    "conclaude-aarch64-apple-darwin.tar.xz": {
+      "name": "conclaude-aarch64-apple-darwin.tar.xz",
+      "kind": "executable-zip",
+      "target_triples": [
+        "aarch64-apple-darwin"
+      ],
+      "assets": [
+        {
+          "name": "README.md",
+          "path": "README.md",
+          "kind": "readme"
+        },
+        {
+          "id": "conclaude-aarch64-apple-darwin-exe-conclaude",
+          "name": "conclaude",
+          "path": "conclaude",
+          "kind": "executable"
+        }
+      ],
+      "checksum": "conclaude-aarch64-apple-darwin.tar.xz.sha256"
+    },
+    "conclaude-aarch64-apple-darwin.tar.xz.sha256": {
+      "name": "conclaude-aarch64-apple-darwin.tar.xz.sha256",
+      "kind": "checksum",
+      "target_triples": [
+        "aarch64-apple-darwin"
+      ]
+    },
+    "conclaude-aarch64-pc-windows-msvc-update": {
+      "name": "conclaude-aarch64-pc-windows-msvc-update",
+      "kind": "updater",
+      "target_triples": [
+        "aarch64-pc-windows-msvc"
+      ]
+    },
+    "conclaude-aarch64-pc-windows-msvc.msi": {
+      "name": "conclaude-aarch64-pc-windows-msvc.msi",
+      "kind": "installer",
+      "target_triples": [
+        "aarch64-pc-windows-msvc"
+      ],
+      "assets": [
+        {
+          "id": "conclaude-aarch64-pc-windows-msvc-exe-conclaude",
+          "name": "conclaude",
+          "path": "conclaude.exe",
+          "kind": "executable"
+        }
+      ],
+      "description": "install via msi",
+      "checksum": "conclaude-aarch64-pc-windows-msvc.msi.sha256"
+    },
+    "conclaude-aarch64-pc-windows-msvc.msi.sha256": {
+      "name": "conclaude-aarch64-pc-windows-msvc.msi.sha256",
+      "kind": "checksum",
+      "target_triples": [
+        "aarch64-pc-windows-msvc"
+      ]
+    },
+    "conclaude-aarch64-pc-windows-msvc.zip": {
+      "name": "conclaude-aarch64-pc-windows-msvc.zip",
+      "kind": "executable-zip",
+      "target_triples": [
+        "aarch64-pc-windows-msvc"
+      ],
+      "assets": [
+        {
+          "name": "README.md",
+          "path": "README.md",
+          "kind": "readme"
+        },
+        {
+          "id": "conclaude-aarch64-pc-windows-msvc-exe-conclaude",
+          "name": "conclaude",
+          "path": "conclaude.exe",
+          "kind": "executable"
+        }
+      ],
+      "checksum": "conclaude-aarch64-pc-windows-msvc.zip.sha256"
+    },
+    "conclaude-aarch64-pc-windows-msvc.zip.sha256": {
+      "name": "conclaude-aarch64-pc-windows-msvc.zip.sha256",
+      "kind": "checksum",
+      "target_triples": [
+        "aarch64-pc-windows-msvc"
+      ]
+    },
+    "conclaude-aarch64-unknown-linux-gnu-update": {
+      "name": "conclaude-aarch64-unknown-linux-gnu-update",
+      "kind": "updater",
+      "target_triples": [
+        "aarch64-unknown-linux-gnu"
+      ]
+    },
+    "conclaude-aarch64-unknown-linux-gnu.tar.xz": {
+      "name": "conclaude-aarch64-unknown-linux-gnu.tar.xz",
+      "kind": "executable-zip",
+      "target_triples": [
+        "aarch64-unknown-linux-gnu"
+      ],
+      "assets": [
+        {
+          "name": "README.md",
+          "path": "README.md",
+          "kind": "readme"
+        },
+        {
+          "id": "conclaude-aarch64-unknown-linux-gnu-exe-conclaude",
+          "name": "conclaude",
+          "path": "conclaude",
+          "kind": "executable"
+        }
+      ],
+      "checksum": "conclaude-aarch64-unknown-linux-gnu.tar.xz.sha256"
+    },
+    "conclaude-aarch64-unknown-linux-gnu.tar.xz.sha256": {
+      "name": "conclaude-aarch64-unknown-linux-gnu.tar.xz.sha256",
+      "kind": "checksum",
+      "target_triples": [
+        "aarch64-unknown-linux-gnu"
+      ]
+    },
+    "conclaude-installer.ps1": {
+      "name": "conclaude-installer.ps1",
+      "kind": "installer",
+      "target_triples": [
+        "aarch64-pc-windows-gnu",
+        "aarch64-pc-windows-msvc",
+        "x86_64-pc-windows-gnu",
+        "x86_64-pc-windows-msvc"
+      ],
+      "install_hint": "powershell -ExecutionPolicy Bypass -c \"irm https://github.com/connix-io/conclaude/releases/download/v0.1.5/conclaude-installer.ps1 | iex\"",
+      "description": "Install prebuilt binaries via powershell script"
+    },
+    "conclaude-installer.sh": {
+      "name": "conclaude-installer.sh",
+      "kind": "installer",
+      "target_triples": [
+        "aarch64-apple-darwin",
+        "aarch64-pc-windows-gnu",
+        "aarch64-unknown-linux-gnu",
+        "x86_64-apple-darwin",
+        "x86_64-pc-windows-gnu",
+        "x86_64-unknown-linux-gnu",
+        "x86_64-unknown-linux-musl-dynamic",
+        "x86_64-unknown-linux-musl-static"
+      ],
+      "install_hint": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/connix-io/conclaude/releases/download/v0.1.5/conclaude-installer.sh | sh",
+      "description": "Install prebuilt binaries via shell script"
+    },
+    "conclaude-npm-package.tar.gz": {
+      "name": "conclaude-npm-package.tar.gz",
+      "kind": "installer",
+      "target_triples": [
+        "aarch64-apple-darwin",
+        "aarch64-pc-windows-gnu",
+        "aarch64-pc-windows-msvc",
+        "aarch64-unknown-linux-gnu",
+        "x86_64-apple-darwin",
+        "x86_64-pc-windows-gnu",
+        "x86_64-pc-windows-msvc",
+        "x86_64-unknown-linux-gnu",
+        "x86_64-unknown-linux-musl-dynamic",
+        "x86_64-unknown-linux-musl-static"
+      ],
+      "assets": [
+        {
+          "name": ".gitignore",
+          "path": ".gitignore",
+          "kind": "unknown"
+        },
+        {
+          "name": "README.md",
+          "path": "README.md",
+          "kind": "readme"
+        },
+        {
+          "name": "binary-install.js",
+          "path": "binary-install.js",
+          "kind": "unknown"
+        },
+        {
+          "name": "binary.js",
+          "path": "binary.js",
+          "kind": "unknown"
+        },
+        {
+          "name": "install.js",
+          "path": "install.js",
+          "kind": "unknown"
+        },
+        {
+          "name": "npm-shrinkwrap.json",
+          "path": "npm-shrinkwrap.json",
+          "kind": "unknown"
+        },
+        {
+          "name": "package.json",
+          "path": "package.json",
+          "kind": "unknown"
+        },
+        {
+          "name": "run.js",
+          "path": "run.js",
+          "kind": "unknown"
+        }
+      ],
+      "install_hint": "npm install conclaude@0.1.5",
+      "description": "Install prebuilt binaries into your npm project"
+    },
+    "conclaude-x86_64-apple-darwin-update": {
+      "name": "conclaude-x86_64-apple-darwin-update",
+      "kind": "updater",
+      "target_triples": [
+        "x86_64-apple-darwin"
+      ]
+    },
+    "conclaude-x86_64-apple-darwin.tar.xz": {
+      "name": "conclaude-x86_64-apple-darwin.tar.xz",
+      "kind": "executable-zip",
+      "target_triples": [
+        "x86_64-apple-darwin"
+      ],
+      "assets": [
+        {
+          "name": "README.md",
+          "path": "README.md",
+          "kind": "readme"
+        },
+        {
+          "id": "conclaude-x86_64-apple-darwin-exe-conclaude",
+          "name": "conclaude",
+          "path": "conclaude",
+          "kind": "executable"
+        }
+      ],
+      "checksum": "conclaude-x86_64-apple-darwin.tar.xz.sha256"
+    },
+    "conclaude-x86_64-apple-darwin.tar.xz.sha256": {
+      "name": "conclaude-x86_64-apple-darwin.tar.xz.sha256",
+      "kind": "checksum",
+      "target_triples": [
+        "x86_64-apple-darwin"
+      ]
+    },
+    "conclaude-x86_64-pc-windows-msvc-update": {
+      "name": "conclaude-x86_64-pc-windows-msvc-update",
+      "kind": "updater",
+      "target_triples": [
+        "x86_64-pc-windows-msvc"
+      ]
+    },
+    "conclaude-x86_64-pc-windows-msvc.msi": {
+      "name": "conclaude-x86_64-pc-windows-msvc.msi",
+      "kind": "installer",
+      "target_triples": [
+        "x86_64-pc-windows-msvc"
+      ],
+      "assets": [
+        {
+          "id": "conclaude-x86_64-pc-windows-msvc-exe-conclaude",
+          "name": "conclaude",
+          "path": "conclaude.exe",
+          "kind": "executable"
+        }
+      ],
+      "description": "install via msi",
+      "checksum": "conclaude-x86_64-pc-windows-msvc.msi.sha256"
+    },
+    "conclaude-x86_64-pc-windows-msvc.msi.sha256": {
+      "name": "conclaude-x86_64-pc-windows-msvc.msi.sha256",
+      "kind": "checksum",
+      "target_triples": [
+        "x86_64-pc-windows-msvc"
+      ]
+    },
+    "conclaude-x86_64-pc-windows-msvc.zip": {
+      "name": "conclaude-x86_64-pc-windows-msvc.zip",
+      "kind": "executable-zip",
+      "target_triples": [
+        "x86_64-pc-windows-msvc"
+      ],
+      "assets": [
+        {
+          "name": "README.md",
+          "path": "README.md",
+          "kind": "readme"
+        },
+        {
+          "id": "conclaude-x86_64-pc-windows-msvc-exe-conclaude",
+          "name": "conclaude",
+          "path": "conclaude.exe",
+          "kind": "executable"
+        }
+      ],
+      "checksum": "conclaude-x86_64-pc-windows-msvc.zip.sha256"
+    },
+    "conclaude-x86_64-pc-windows-msvc.zip.sha256": {
+      "name": "conclaude-x86_64-pc-windows-msvc.zip.sha256",
+      "kind": "checksum",
+      "target_triples": [
+        "x86_64-pc-windows-msvc"
+      ]
+    },
+    "conclaude-x86_64-unknown-linux-gnu-update": {
+      "name": "conclaude-x86_64-unknown-linux-gnu-update",
+      "kind": "updater",
+      "target_triples": [
+        "x86_64-unknown-linux-gnu"
+      ]
+    },
+    "conclaude-x86_64-unknown-linux-gnu.tar.xz": {
+      "name": "conclaude-x86_64-unknown-linux-gnu.tar.xz",
+      "kind": "executable-zip",
+      "target_triples": [
+        "x86_64-unknown-linux-gnu"
+      ],
+      "assets": [
+        {
+          "name": "README.md",
+          "path": "README.md",
+          "kind": "readme"
+        },
+        {
+          "id": "conclaude-x86_64-unknown-linux-gnu-exe-conclaude",
+          "name": "conclaude",
+          "path": "conclaude",
+          "kind": "executable"
+        }
+      ],
+      "checksum": "conclaude-x86_64-unknown-linux-gnu.tar.xz.sha256"
+    },
+    "conclaude-x86_64-unknown-linux-gnu.tar.xz.sha256": {
+      "name": "conclaude-x86_64-unknown-linux-gnu.tar.xz.sha256",
+      "kind": "checksum",
+      "target_triples": [
+        "x86_64-unknown-linux-gnu"
+      ]
+    },
+    "conclaude-x86_64-unknown-linux-musl-update": {
+      "name": "conclaude-x86_64-unknown-linux-musl-update",
+      "kind": "updater",
+      "target_triples": [
+        "x86_64-unknown-linux-musl"
+      ]
+    },
+    "conclaude-x86_64-unknown-linux-musl.tar.xz": {
+      "name": "conclaude-x86_64-unknown-linux-musl.tar.xz",
+      "kind": "executable-zip",
+      "target_triples": [
+        "x86_64-unknown-linux-musl"
+      ],
+      "assets": [
+        {
+          "name": "README.md",
+          "path": "README.md",
+          "kind": "readme"
+        },
+        {
+          "id": "conclaude-x86_64-unknown-linux-musl-exe-conclaude",
+          "name": "conclaude",
+          "path": "conclaude",
+          "kind": "executable"
+        }
+      ],
+      "checksum": "conclaude-x86_64-unknown-linux-musl.tar.xz.sha256"
+    },
+    "conclaude-x86_64-unknown-linux-musl.tar.xz.sha256": {
+      "name": "conclaude-x86_64-unknown-linux-musl.tar.xz.sha256",
+      "kind": "checksum",
+      "target_triples": [
+        "x86_64-unknown-linux-musl"
+      ]
+    },
+    "sha256.sum": {
+      "name": "sha256.sum",
+      "kind": "unified-checksum"
+    },
+    "source.tar.gz": {
+      "name": "source.tar.gz",
+      "kind": "source-tarball",
+      "checksum": "source.tar.gz.sha256"
+    },
+    "source.tar.gz.sha256": {
+      "name": "source.tar.gz.sha256",
+      "kind": "checksum"
+    }
+  },
+  "systems": {
+    "host::all:": {
+      "id": "host::all:",
+      "cargo_version_line": "cargo 1.89.0 (c24e10642 2025-06-23)",
+      "build_environment": {
+        "linux": {
+          "glibc_version": {
+            "major": 2,
+            "series": 40
+          }
+        }
+      }
+    },
+    "host:create:all:": {
+      "id": "host:create:all:",
+      "cargo_version_line": "cargo 1.89.0 (c24e10642 2025-06-23)",
+      "build_environment": {
+        "linux": {
+          "glibc_version": {
+            "major": 2,
+            "series": 40
+          }
+        }
+      }
+    }
+  },
+  "publish_prereleases": false,
+  "force_latest": false,
+  "ci": {
+    "github": {
+      "artifacts_matrix": {
+        "include": [
+          {
+            "runner": "macos-13",
+            "host": "x86_64-apple-darwin",
+            "install_dist": {
+              "shell": "sh",
+              "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/v0.29.0/cargo-dist-installer.sh | sh"
+            },
+            "dist_args": "--artifacts=local --target=aarch64-apple-darwin",
+            "targets": [
+              "aarch64-apple-darwin"
+            ],
+            "cache_provider": "github"
+          },
+          {
+            "runner": "ubuntu-22.04",
+            "host": "x86_64-unknown-linux-gnu",
+            "container": {
+              "image": "messense/cargo-xwin",
+              "host": "x86_64-unknown-linux-musl",
+              "package_manager": "apt"
+            },
+            "install_dist": {
+              "shell": "sh",
+              "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/v0.29.0/cargo-dist-installer.sh | sh"
+            },
+            "dist_args": "--artifacts=local --target=aarch64-pc-windows-msvc",
+            "targets": [
+              "aarch64-pc-windows-msvc"
+            ],
+            "packages_install": "if ! command -v cargo-xwin > /dev/null 2>&1; then\n  if ! command -v pip3 > /dev/null 2>&1; then\n    dnf install --assumeyes python3-pip\n    pip3 install --upgrade pip\n  fi\n  pip3 install cargo-xwin\nfi",
+            "cache_provider": "github"
+          },
+          {
+            "runner": "ubuntu-22.04",
+            "host": "x86_64-unknown-linux-gnu",
+            "install_dist": {
+              "shell": "sh",
+              "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/v0.29.0/cargo-dist-installer.sh | sh"
+            },
+            "dist_args": "--artifacts=local --target=aarch64-unknown-linux-gnu",
+            "targets": [
+              "aarch64-unknown-linux-gnu"
+            ],
+            "packages_install": "if ! command -v cargo-zigbuild > /dev/null 2>&1; then\n  if ! command -v pip3 > /dev/null 2>&1; then\n    dnf install --assumeyes python3-pip\n    pip3 install --upgrade pip\n  fi\n  pip3 install cargo-zigbuild\nfi",
+            "cache_provider": "github"
+          },
+          {
+            "runner": "macos-13",
+            "host": "x86_64-apple-darwin",
+            "install_dist": {
+              "shell": "sh",
+              "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/v0.29.0/cargo-dist-installer.sh | sh"
+            },
+            "dist_args": "--artifacts=local --target=x86_64-apple-darwin",
+            "targets": [
+              "x86_64-apple-darwin"
+            ],
+            "cache_provider": "github"
+          },
+          {
+            "runner": "windows-2022",
+            "host": "x86_64-pc-windows-msvc",
+            "install_dist": {
+              "shell": "pwsh",
+              "run": "irm https://github.com/axodotdev/cargo-dist/releases/download/v0.29.0/cargo-dist-installer.ps1 | iex"
+            },
+            "dist_args": "--artifacts=local --target=x86_64-pc-windows-msvc",
+            "targets": [
+              "x86_64-pc-windows-msvc"
+            ],
+            "cache_provider": "github"
+          },
+          {
+            "runner": "ubuntu-22.04",
+            "host": "x86_64-unknown-linux-gnu",
+            "install_dist": {
+              "shell": "sh",
+              "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/v0.29.0/cargo-dist-installer.sh | sh"
+            },
+            "dist_args": "--artifacts=local --target=x86_64-unknown-linux-gnu",
+            "targets": [
+              "x86_64-unknown-linux-gnu"
+            ],
+            "cache_provider": "github"
+          },
+          {
+            "runner": "ubuntu-22.04",
+            "host": "x86_64-unknown-linux-gnu",
+            "install_dist": {
+              "shell": "sh",
+              "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/v0.29.0/cargo-dist-installer.sh | sh"
+            },
+            "dist_args": "--artifacts=local --target=x86_64-unknown-linux-musl",
+            "targets": [
+              "x86_64-unknown-linux-musl"
+            ],
+            "packages_install": "sudo apt-get update\nsudo apt-get install musl-tools",
+            "cache_provider": "github"
+          }
+        ]
+      },
+      "pr_run_mode": "plan"
+    }
+  },
+  "linkage": [],
+  "upload_files": []
+}


### PR DESCRIPTION
- Bump version in Cargo.lock from 0.1.3 to 0.1.5
- Remove aarch64-pc-windows-msvc from build targets in dist-workspace.toml to streamline supported platforms and potentially address build issues
- Add plan-dist-manifest.json, a new manifest file generated by cargo-dist for planning and managing software distributions across multiple platforms
