### PR TITLE
Fix changelog workflow to use git-cliff action

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -24,13 +24,12 @@ jobs:
 
       # Generate changelog using git-cliff
       - name: Generate changelog
-        uses: orhun/git-cliff-action@v3
+        uses: orhun/git-cliff-action@104a6cf3c9aa0fdfe4eab129f9c1900e1eb8f7fd # main
         with:
           config: cliff.toml
-          args: --verbose --tag ${{ github.ref_name }}
+          args: -vv --tag ${{ github.ref_name }} --github-repo ${{ github.repository }}
         env:
           OUTPUT: CHANGELOG.md
-          GITHUB_REPO: ${{ github.repository }}
 
       # Configure git with bot credentials
       - name: Configure git

--- a/cliff.toml
+++ b/cliff.toml
@@ -22,7 +22,7 @@ body = """
     {% for commit in commits %}
         - {% if commit.scope %}**{{ commit.scope }}:** {% endif %}\
             {% if commit.breaking %}[**breaking**] {% endif %}\
-            {{ commit.message | upper_first }} ([{{ commit.id | truncate(length=7, end="") }}](https://github.com/{{ env::var(name="GITHUB_REPO") | default(value="connix-io/conclaude") }}/commit/{{ commit.id }}))\
+            {{ commit.message | upper_first }} ([{{ commit.id | truncate(length=7, end="") }}](https://github.com/{{ remote.github.owner }}/{{ remote.github.repo }}/commit/{{ commit.id }}))\
     {% endfor %}
 {% endfor %}\n
 """

--- a/flake.nix
+++ b/flake.nix
@@ -118,6 +118,7 @@
             napi-rs-cli
             yarn
             cargo-dist
+            git-cliff
           ]
           ++ builtins.attrValues scriptPackages;
         shellHook = ''


### PR DESCRIPTION
## Summary

Fixes the failing changelog workflow on main by replacing the nix-based approach with the proven git-cliff GitHub action from the official git-cliff repository.

- **Replace git-cliff action reference**: Changed from version tag `@v3` to commit hash `@104a6cf3c9aa0fdfe4eab129f9c1900e1eb8f7fd` for security and reproducibility (matches official git-cliff repo approach)
- **Update action arguments**: Changed to `-vv --tag --github-repo` to properly provide repository information to git-cliff
- **Fix cliff.toml template syntax**: Updated from Rust-style `env::var(name="GITHUB_REPO")` to proper Tera template syntax `remote.github.owner`/`remote.github.repo` (populated automatically by `--github-repo` flag)
- **Add git-cliff to flake.nix**: Added to buildInputs for convenient local development

## Test plan

- [ ] Verify workflow file syntax is valid
- [ ] Check that git-cliff action version/hash is correct
- [ ] Confirm cliff.toml uses proper Tera template variables
- [ ] Test workflow triggers on version tag push (e.g., push a test tag like `v0.2.1`)
- [ ] Verify CHANGELOG.md is generated correctly with proper GitHub commit links
- [ ] Ensure changes are committed and pushed to main by the workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD configuration for changelog generation workflow.
  * Enhanced changelog generation configuration to dynamically retrieve GitHub repository metadata.
  * Updated development environment tooling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->