### PR TITLE
lowprob - Add uneditable range markers for all languages

### DIFF
--- a/spectr/changes/add-uneditable-markers/design.md
+++ b/spectr/changes/add-uneditable-markers/design.md
@@ -1,0 +1,521 @@
+# Design: Uneditable Code Range Markers
+
+## Context
+
+This design document describes the technical approach for implementing in-code uneditable range markers. The feature allows developers to protect specific code ranges from modification by embedding markers in comments, working across all programming languages.
+
+**Stakeholders:**
+- Developers protecting critical code sections
+- Claude Code (AI assistant respecting protection markers)
+- conclaude (enforcing protection rules)
+
+**Constraints:**
+- Must work across all major programming languages
+- Must not break existing file protection mechanisms
+- Must have minimal performance impact (< 10ms per file check)
+- Must provide clear, actionable error messages
+
+## Goals / Non-Goals
+
+### Goals
+1. Support uneditable range markers in all major programming languages
+2. Detect and validate markers at PreToolUse hook before tool execution
+3. Block `Edit` and `Write` operations that would modify protected ranges
+4. Provide clear error messages indicating which ranges are protected
+5. Handle edge cases gracefully (nested markers, unclosed markers, etc.)
+
+### Non-Goals
+1. **NOT** providing automatic marker insertion or management tools (future work)
+2. **NOT** supporting region-based markers (e.g., `#region`/`#endregion`) - only comment-based
+3. **NOT** runtime enforcement (markers are static, checked before edits)
+4. **NOT** supporting partial-line protection (entire lines are protected)
+
+## Architecture
+
+### Component Overview
+
+```
+┌─────────────────────────────────────────────────────┐
+│           PreToolUse Hook (hooks.rs)                │
+│  - Receives Edit/Write tool payloads                │
+│  - Extracts file path and edit range                │
+│  - Calls marker detection & validation              │
+└────────────────────┬────────────────────────────────┘
+                     │
+                     ▼
+┌─────────────────────────────────────────────────────┐
+│        Marker Detection (markers.rs - NEW)          │
+│  - Detect language from file extension              │
+│  - Map language to comment syntax                   │
+│  - Parse file for markers                           │
+│  - Extract protected ranges                         │
+└────────────────────┬────────────────────────────────┘
+                     │
+                     ▼
+┌─────────────────────────────────────────────────────┐
+│         Range Validation (markers.rs)               │
+│  - Check if edit range overlaps protected range     │
+│  - Validate marker pairing (start/end matched)      │
+│  - Detect nested/malformed markers                  │
+└────────────────────┬────────────────────────────────┘
+                     │
+                     ▼
+┌─────────────────────────────────────────────────────┐
+│         HookResult (types.rs)                       │
+│  - Return blocked result if overlap detected        │
+│  - Return allowed if no overlap                     │
+└─────────────────────────────────────────────────────┘
+```
+
+### Data Flow
+
+1. **Claude Code** attempts `Edit` or `Write` operation
+2. **PreToolUse hook** receives payload with file path and tool parameters
+3. **Marker detector** reads target file and scans for markers
+4. **Language detector** determines comment syntax based on file extension
+5. **Parser** extracts protected ranges (line numbers)
+6. **Validator** checks if edit range overlaps with any protected range
+7. **Hook** returns `HookResult::blocked()` if overlap, `HookResult::allowed()` otherwise
+
+### Language Detection Strategy
+
+**Approach:** Extension-based mapping with fallback to heuristics
+
+```rust
+// Simplified pseudocode
+fn detect_language(file_path: &Path) -> Language {
+    match file_path.extension().and_then(|e| e.to_str()) {
+        Some("go") => Language::Go,
+        Some("py") => Language::Python,
+        Some("js") => Language::JavaScript,
+        Some("ts") | Some("tsx") => Language::TypeScript,
+        Some("rs") => Language::Rust,
+        Some("java") => Language::Java,
+        Some("c") | Some("h") => Language::C,
+        Some("cpp") | Some("cc") | Some("hpp") => Language::Cpp,
+        Some("rb") => Language::Ruby,
+        Some("php") => Language::Php,
+        Some("sh") | Some("bash") => Language::Shell,
+        _ => Language::Unknown, // Fallback: try generic comment patterns
+    }
+}
+```
+
+### Comment Syntax Mapping
+
+Each language maps to its comment syntax pattern(s):
+
+```rust
+pub enum CommentStyle {
+    DoubleSlash,      // Go, Rust, JavaScript, TypeScript, C++, Java
+    Hash,             // Python, Ruby, Shell
+    DoubleSlashBlock, // C-style /* */ (future)
+    Mixed,            // Languages with multiple comment styles
+}
+
+fn get_comment_pattern(lang: Language) -> Vec<&'static str> {
+    match lang {
+        Language::Go | Language::Rust | Language::JavaScript
+        | Language::TypeScript | Language::Java | Language::Cpp => {
+            vec!["//"]
+        },
+        Language::Python | Language::Ruby | Language::Shell => {
+            vec!["#"]
+        },
+        Language::C => {
+            vec!["//", "/*"] // Support both styles
+        },
+        _ => {
+            vec!["//", "#", "/*"] // Try all common patterns
+        }
+    }
+}
+```
+
+### Marker Detection Algorithm
+
+**Input:** File content (String), comment patterns (Vec<&str>)
+**Output:** Vec<ProtectedRange> with line numbers
+
+```rust
+pub struct ProtectedRange {
+    pub start_line: usize,  // Inclusive (1-indexed)
+    pub end_line: usize,    // Inclusive (1-indexed)
+    pub reason: Option<String>, // Optional custom message
+}
+
+fn extract_protected_ranges(
+    content: &str,
+    comment_patterns: &[&str]
+) -> Result<Vec<ProtectedRange>> {
+    let mut ranges = Vec::new();
+    let mut stack = Vec::new(); // For tracking nested markers
+
+    for (line_num, line) in content.lines().enumerate() {
+        let line_num = line_num + 1; // Convert to 1-indexed
+
+        for pattern in comment_patterns {
+            let comment_start = line.find(pattern);
+            if let Some(pos) = comment_start {
+                let comment_text = &line[pos..];
+
+                if comment_text.contains("<!-- conclaude-uneditable:start -->") {
+                    stack.push(line_num);
+                } else if comment_text.contains("<!-- conclaude-uneditable:end -->") {
+                    if let Some(start) = stack.pop() {
+                        ranges.push(ProtectedRange {
+                            start_line: start,
+                            end_line: line_num,
+                            reason: None,
+                        });
+                    } else {
+                        return Err(anyhow!("Unmatched end marker at line {}", line_num));
+                    }
+                }
+            }
+        }
+    }
+
+    if !stack.is_empty() {
+        return Err(anyhow!("Unclosed protected range starting at line {}", stack[0]));
+    }
+
+    Ok(ranges)
+}
+```
+
+### Edit Range Overlap Detection
+
+**Input:** Edit range (start, end), Protected ranges
+**Output:** bool (overlap detected)
+
+```rust
+fn has_overlap(
+    edit_start: usize,
+    edit_end: usize,
+    protected: &ProtectedRange
+) -> bool {
+    // Check if ranges overlap
+    !(edit_end < protected.start_line || edit_start > protected.end_line)
+}
+
+fn check_edit_allowed(
+    edit_start: usize,
+    edit_end: usize,
+    protected_ranges: &[ProtectedRange]
+) -> Option<&ProtectedRange> {
+    protected_ranges.iter()
+        .find(|range| has_overlap(edit_start, edit_end, range))
+}
+```
+
+### Integration with PreToolUse Hook
+
+**Modified `handle_pre_tool_use` in `hooks.rs`:**
+
+```rust
+async fn handle_pre_tool_use(
+    payload: &PreToolUsePayload,
+    config: &ConclaudeConfig,
+    config_dir: &Path,
+) -> Result<Option<HookResult>> {
+    // ... existing validation logic (uneditableFiles, etc.) ...
+
+    // NEW: Check for uneditable markers if Edit or Write tool
+    if payload.tool_name == "Edit" || payload.tool_name == "Write" {
+        if let Some(blocked_reason) = check_uneditable_markers(payload, config_dir)? {
+            return Ok(Some(HookResult::blocked(blocked_reason)));
+        }
+    }
+
+    // ... rest of validation ...
+}
+
+fn check_uneditable_markers(
+    payload: &PreToolUsePayload,
+    config_dir: &Path,
+) -> Result<Option<String>> {
+    // Extract file path from payload
+    let file_path = extract_file_path(payload)?;
+
+    // Read file content
+    let content = fs::read_to_string(&file_path)?;
+
+    // Detect language and get comment patterns
+    let language = detect_language(&file_path);
+    let patterns = get_comment_patterns(language);
+
+    // Extract protected ranges
+    let protected_ranges = extract_protected_ranges(&content, &patterns)?;
+
+    if protected_ranges.is_empty() {
+        return Ok(None); // No markers, allow operation
+    }
+
+    // Extract edit range from payload
+    let (edit_start, edit_end) = extract_edit_range(payload)?;
+
+    // Check for overlap
+    if let Some(blocked_range) = check_edit_allowed(edit_start, edit_end, &protected_ranges) {
+        let message = format!(
+            "Blocked {} operation: attempting to modify protected range (lines {}-{}) in {}.\n\
+             Protected range is marked with 'conclaude-uneditable' markers.",
+            payload.tool_name,
+            blocked_range.start_line,
+            blocked_range.end_line,
+            file_path.display()
+        );
+        return Ok(Some(message));
+    }
+
+    Ok(None) // No overlap, allow operation
+}
+```
+
+## Decisions
+
+### Decision 1: Always-On Feature (No Configuration Required)
+
+**Decision:** Enable marker detection automatically whenever markers are present in files.
+
+**Rationale:**
+- Simplicity: No configuration needed to use the feature
+- Explicit intent: Developers who add markers clearly want protection
+- Backward compatible: Files without markers are unaffected
+- Discoverability: No hidden configuration to discover
+
+**Alternatives considered:**
+- Require opt-in via `rules.enableUneditableMarkers: true`
+  - **Rejected**: Adds friction, makes feature less discoverable
+- Make it opt-out via `rules.disableUneditableMarkers: true`
+  - **Rejected**: Default-on is simpler, opt-out rarely needed
+
+### Decision 2: Block Entire Edit if Any Protected Line Touched
+
+**Decision:** Block the entire `Edit` or `Write` operation if it overlaps with any protected range, even partially.
+
+**Rationale:**
+- **Safety first**: Prevents accidental modification of protected code
+- **Simplicity**: Clear, unambiguous rule
+- **Predictability**: Easy to understand and explain to users
+- **Implementation**: Simpler validation logic
+
+**Alternatives considered:**
+- **Allow edit if protected lines remain unchanged**
+  - **Rejected**: Would require diff-based validation, complex edge cases
+  - Example complexity: What if edit changes indentation of protected line?
+- **Split edit into allowed/blocked portions**
+  - **Rejected**: Claude Code API doesn't support partial edit approval
+
+### Decision 3: Include Marker Lines in Protected Range
+
+**Decision:** The lines containing `start` and `end` markers are themselves part of the protected range.
+
+**Rationale:**
+- Prevents marker removal (deleting markers would disable protection)
+- Prevents marker modification (changing marker format could break detection)
+- Intuitive: "Everything between and including these markers is protected"
+
+**Example:**
+```python
+# Line 10
+# <!-- conclaude-uneditable:start -->   <- Protected (line 11)
+SECRET_KEY = "do-not-modify"             <- Protected (line 12)
+# <!-- conclaude-uneditable:end -->     <- Protected (line 13)
+# Line 14
+```
+
+Protected range: lines 11-13 (inclusive)
+
+### Decision 4: Report Error on Nested/Malformed Markers
+
+**Decision:** Detect and report errors for nested, overlapping, or unclosed markers.
+
+**Rationale:**
+- **Data integrity**: Malformed markers likely indicate user error
+- **Clear feedback**: Better to fail fast with clear error than silently ignore
+- **Maintainability**: Prevents confusing protection states
+
+**Error cases:**
+1. **Unclosed start marker**: Start without matching end
+2. **Unmatched end marker**: End without matching start
+3. **Nested markers**: Start-start-end-end sequence (currently disallowed)
+
+**Error response:**
+- Block ALL edits to file containing malformed markers
+- Return clear error message indicating the issue and line numbers
+
+**Future consideration:** Could support nested markers if use case emerges
+
+### Decision 5: Language Detection by Extension Only (V1)
+
+**Decision:** Use file extension mapping for language detection; fallback to trying all common comment patterns if extension unknown.
+
+**Rationale:**
+- **Simplicity**: Extension mapping is fast and deterministic
+- **Coverage**: Covers 95%+ of real-world use cases
+- **Fallback**: Unknown extensions still work via pattern matching all styles
+- **Future-proof**: Can add shebang detection or content sniffing later if needed
+
+**Supported extensions (V1):**
+- `.go` → Go (// comments)
+- `.py` → Python (# comments)
+- `.js`, `.jsx` → JavaScript (// comments)
+- `.ts`, `.tsx` → TypeScript (// comments)
+- `.rs` → Rust (// comments)
+- `.java` → Java (// comments)
+- `.c`, `.h` → C (// or /* */ comments)
+- `.cpp`, `.cc`, `.hpp` → C++ (// or /* */ comments)
+- `.rb` → Ruby (# comments)
+- `.php` → PHP (// or # comments)
+- `.sh`, `.bash` → Shell (# comments)
+
+**Unknown extensions:** Try all patterns (`//`, `#`, `/*`)
+
+## Risks / Trade-offs
+
+### Risk 1: Performance Impact on Large Files
+
+**Risk:** Scanning large files (> 10K lines) for markers could slow down PreToolUse hook.
+
+**Mitigation:**
+- Early exit: Stop scanning after finding relevant ranges for edit
+- Caching: Cache marker positions per file (future optimization)
+- Lazy loading: Only scan if file is being edited, not on every PreToolUse
+- Benchmarking: Set performance budget (< 10ms per file)
+
+**Acceptance:** For V1, accept small performance impact; optimize if profiling shows issues
+
+### Risk 2: Marker Format Collisions
+
+**Risk:** Code might legitimately contain `<!-- conclaude-uneditable:start -->` in strings or documentation.
+
+**Mitigation:**
+- Require marker to appear in comment (not in string literals)
+- Use unique marker format unlikely to collide (`conclaude-uneditable` namespace)
+- Document proper usage in README
+
+**Acceptance:** Low probability; explicit format makes collisions unlikely
+
+### Risk 3: Partial File Edits Could Be Confusing
+
+**Risk:** If Claude Code wants to edit multiple ranges, some allowed and some blocked, the error message might be unclear.
+
+**Mitigation:**
+- Clear error messages indicating specific line numbers protected
+- Consider future enhancement: allow multiple edits, block only conflicting ones
+
+**Acceptance:** V1 blocks entire operation; can enhance UX in future iterations
+
+### Risk 4: Language Coverage Gaps
+
+**Risk:** New or obscure languages might not have comment syntax mapped.
+
+**Mitigation:**
+- Fallback to trying all common patterns
+- Allow future configuration for custom comment syntax (if needed)
+- Community can request language additions via issues
+
+**Acceptance:** Fallback handles most cases; can expand language list incrementally
+
+## Migration Plan
+
+**No migration needed** - this is a new, additive feature.
+
+**Adoption path:**
+1. Users add markers to files where they want protection
+2. conclaude automatically detects and enforces markers
+3. No configuration changes required
+
+**Backward compatibility:**
+- Files without markers: No change in behavior
+- Existing `uneditableFiles` rules: Continue to work independently
+- Configuration: No breaking changes
+
+## Testing Strategy
+
+### Unit Tests
+
+1. **Marker detection:**
+   - Correctly parse start/end markers
+   - Handle multiple protected ranges in same file
+   - Detect unclosed markers
+   - Detect unmatched end markers
+   - Handle empty files
+   - Handle files with no markers
+
+2. **Language detection:**
+   - Map extensions to correct languages
+   - Handle unknown extensions (fallback)
+   - Support multiple comment patterns per language
+
+3. **Overlap detection:**
+   - Detect overlap when edit starts inside range
+   - Detect overlap when edit ends inside range
+   - Detect overlap when edit fully contains range
+   - Detect overlap when edit is fully contained by range
+   - Allow edit when no overlap
+
+### Integration Tests
+
+1. **PreToolUse hook integration:**
+   - Block Edit operation touching protected range
+   - Allow Edit operation outside protected range
+   - Block Write operation overwriting protected file
+   - Return clear error messages
+
+2. **Multi-language tests:**
+   - Verify Go files with `//` comments
+   - Verify Python files with `#` comments
+   - Verify JavaScript files with `//` comments
+   - Verify Rust files with `//` comments
+
+3. **Edge cases:**
+   - Nested markers (should error)
+   - Markers in string literals (should ignore if not in comment)
+   - Empty ranges (start and end on consecutive lines)
+   - Very large files (performance test)
+
+## Open Questions
+
+1. **Custom marker formats:** Should users be able to configure alternative marker patterns in `.conclaude.yml`?
+   - **Deferred to V2** - start with fixed format, add configuration if requested
+
+2. **Marker metadata:** Should markers support optional metadata (e.g., reason, owner)?
+   ```python
+   # <!-- conclaude-uneditable:start reason="Generated by Prisma" -->
+   ```
+   - **Deferred to V2** - start simple, add metadata if use cases emerge
+
+3. **Performance optimization:** Should we cache marker positions to avoid re-parsing?
+   - **Deferred until profiling** - implement V1, measure, optimize if needed
+
+4. **IDE integration:** Should we provide VS Code extension to highlight protected ranges?
+   - **Out of scope** - nice-to-have, separate project
+
+## Success Metrics
+
+- Feature successfully blocks edits to protected ranges
+- Performance impact < 10ms per file on typical codebases (< 5K lines)
+- Zero false positives (legitimate edits not blocked)
+- Zero false negatives (protected ranges not missed)
+- Clear error messages (user understands why blocked)
+
+## Implementation Phases
+
+### Phase 1: Core Functionality (MVP)
+- Marker detection for core languages (Go, Python, JS, TS, Rust)
+- Basic overlap detection
+- PreToolUse integration
+- Unit tests
+
+### Phase 2: Language Expansion
+- Add support for additional languages (Java, C/C++, Ruby, PHP, Shell)
+- Fallback handling for unknown extensions
+- Integration tests across all languages
+
+### Phase 3: Polish & Edge Cases
+- Nested marker detection
+- Improved error messages
+- Performance optimization (if needed)
+- Documentation and examples

--- a/spectr/changes/add-uneditable-markers/proposal.md
+++ b/spectr/changes/add-uneditable-markers/proposal.md
@@ -1,0 +1,203 @@
+# Proposal: Uneditable Code Range Markers
+
+## Why
+
+Currently, conclaude can protect entire files from modification using `uneditableFiles` glob patterns. However, there are many scenarios where only *specific ranges* within a file should be protected while allowing edits to other parts:
+
+- **Generated code blocks** within otherwise editable files (e.g., Prisma schema sections, OpenAPI spec sections)
+- **Critical configuration sections** that should remain stable (e.g., security settings, database connection strings)
+- **Template boilerplate** that must remain intact while allowing customization elsewhere
+- **License headers** or copyright notices that cannot be modified
+- **Auto-generated imports** or type definitions managed by tooling
+
+Protecting these ranges requires a mechanism to mark specific line ranges as uneditable using in-code markers that work across all programming languages.
+
+## What Changes
+
+Add support for **in-code uneditable range markers** that protect specific line ranges from being modified by Claude Code. The markers use HTML-comment-style syntax embedded in language-specific comments:
+
+**Go example:**
+```go
+package main
+
+// <!-- conclaude-uneditable:start -->
+const CriticalConfig = "DO_NOT_MODIFY"
+// <!-- conclaude-uneditable:end -->
+
+// This code can be edited
+func main() {
+    // ...
+}
+```
+
+**Python example:**
+```python
+# -*- coding: utf-8 -*-
+
+# <!-- conclaude-uneditable:start -->
+SECRET_KEY = "production-secret-key-do-not-change"
+# <!-- conclaude-uneditable:end -->
+
+# This code can be edited
+def main():
+    pass
+```
+
+**JavaScript/TypeScript example:**
+```typescript
+// <!-- conclaude-uneditable:start -->
+export const API_VERSION = "v1.0.0";
+export const API_ENDPOINT = "https://api.example.com";
+// <!-- conclaude-uneditable:end -->
+
+// This code can be edited
+export function fetchData() {
+  // ...
+}
+```
+
+**Rust example:**
+```rust
+// <!-- conclaude-uneditable:start -->
+const DATABASE_URL: &str = "postgresql://prod-db";
+// <!-- conclaude-uneditable:end -->
+
+// This code can be edited
+fn main() {
+    // ...
+}
+```
+
+## Key Features
+
+1. **Language-agnostic marker syntax**: `<!-- conclaude-uneditable:start -->` and `<!-- conclaude-uneditable:end -->` work in any comment
+2. **Multi-language support**: Automatic detection of comment syntax for major languages (Go, Python, JavaScript, TypeScript, Rust, Java, C/C++, Ruby, etc.)
+3. **PreToolUse validation**: Blocks `Edit` and `Write` operations that attempt to modify protected ranges
+4. **Clear error messages**: Informs Claude Code which ranges are protected and why the operation was blocked
+5. **Nested range handling**: Detects and reports errors for improperly nested markers
+6. **File-based detection**: Scans target files for markers before applying edits
+
+## Impact
+
+- **Affected specs**:
+  - New capability: `validation-rules` (range-based protection logic)
+  - New capability: `language-support` (comment syntax detection)
+- **Affected code**:
+  - `src/hooks.rs` - Add range validation logic to `handle_pre_tool_use` hook
+  - `src/types.rs` - Add marker detection and range extraction types/functions
+  - New module: `src/markers.rs` - Language detection and marker parsing
+  - `src/config.rs` - Optional configuration for custom marker patterns (future)
+- **Breaking changes**: **None** - This is an additive feature
+- **Performance**: Minimal impact - only scans files that are being edited/written
+
+## Examples
+
+### Blocking an Edit that touches protected range
+
+**File: config.py**
+```python
+# <!-- conclaude-uneditable:start -->
+DATABASE_URL = "postgresql://prod.db"
+API_KEY = "super-secret-key"
+# <!-- conclaude-uneditable:end -->
+
+DEBUG_MODE = False
+```
+
+**Claude Code attempts:**
+```python
+# Edit tool targeting lines 2-3
+DATABASE_URL = "postgresql://dev.db"  # ❌ BLOCKED
+```
+
+**Result:**
+```
+Blocked Edit operation: attempting to modify protected range (lines 1-3) in config.py.
+Protected range is marked with 'conclaude-uneditable' markers.
+```
+
+### Allowing edits outside protected range
+
+**Same file, different edit:**
+```python
+# Edit tool targeting line 5
+DEBUG_MODE = True  # ✅ ALLOWED
+```
+
+## Design Considerations
+
+1. **Marker format**: Use HTML-comment style for familiarity and universal recognizability
+2. **Comment detection**: Map file extensions to known comment syntaxes (with fallback to generic patterns)
+3. **Range boundaries**: Include marker lines themselves in the protected range
+4. **Validation timing**: Check at PreToolUse hook before tool executes
+5. **Error handling**: Clear, actionable error messages indicating which lines are protected
+
+## Alternatives Considered
+
+1. **Use language-specific markers** (e.g., `@conclaude-uneditable` in comments)
+   - **Rejected**: Would require different markers per language, harder to remember and maintain
+
+2. **Use pragma-style markers** (e.g., `#pragma conclaude uneditable`)
+   - **Rejected**: Not all languages support pragma directives; less universal than comments
+
+3. **Configure ranges in `.conclaude.yml`** (e.g., `file.py:10-20`)
+   - **Rejected**: Separates protection from code, brittle to line number changes, harder to maintain
+
+4. **Support only specific languages initially**
+   - **Considered**: Could start with top 5 languages (Go, Python, JS, TS, Rust) and expand later
+
+## Open Questions
+
+Before finalizing the proposal, I need clarification on:
+
+1. **Marker customization**: Should users be able to configure custom marker patterns in `.conclaude.yml`?
+   - Default: `<!-- conclaude-uneditable:start/end -->`
+   - Custom example: `@protected:start/@protected:end`
+
+2. **Nested markers**: How should nested/overlapping markers be handled?
+   - Option A: Report error and block all edits to file
+   - Option B: Merge into single protected range
+   - Option C: Support nested ranges with innermost taking precedence
+
+3. **Language coverage**: Should we support all languages immediately or start with a core set?
+   - Core set: Go, Python, JavaScript, TypeScript, Rust, Java, C/C++, Ruby, PHP, Shell
+   - Full set: Include less common languages (Haskell, Scala, Kotlin, Swift, etc.)
+
+4. **Partial line edits**: If an edit operation spans both protected and unprotected lines, should it:
+   - Option A: Block entirely if any protected lines are touched
+   - Option B: Allow if protected lines remain unchanged (more complex validation)
+
+5. **Configuration opt-in**: Should this feature be:
+   - Option A: Always enabled (if markers present, they're enforced)
+   - Option B: Require explicit opt-in in `.conclaude.yml` (`rules.enableUneditableMarkers: true`)
+
+## Success Criteria
+
+- [ ] Markers correctly detected in all supported language file types
+- [ ] `Edit` operations blocked when modifying protected ranges
+- [ ] `Write` operations blocked when overwriting files with protected content
+- [ ] Clear error messages indicate which lines are protected
+- [ ] Improperly nested markers detected and reported
+- [ ] All tests pass
+- [ ] Documentation includes examples for major languages
+- [ ] Performance impact is negligible (< 10ms overhead per file check)
+
+## Files Affected
+
+- `src/hooks.rs` - PreToolUse hook validation logic
+- `src/markers.rs` (new) - Marker parsing and language detection
+- `src/types.rs` - Protected range types and error responses
+- `src/config.rs` - Optional configuration fields (if custom markers supported)
+- `conclaude-schema.json` - Regenerated schema
+- Documentation (README, examples)
+
+## Timeline
+
+This is a moderately complex feature requiring:
+- Language detection logic (comment syntax mapping)
+- Marker parsing and range extraction
+- Integration with existing PreToolUse hook
+- Comprehensive testing across multiple languages
+- Clear error messaging and documentation
+
+Estimated complexity: **Medium** (requires careful design for language support and edge cases)

--- a/spectr/changes/add-uneditable-markers/specs/language-support/spec.md
+++ b/spectr/changes/add-uneditable-markers/specs/language-support/spec.md
@@ -1,0 +1,219 @@
+# Specification: Language Support (Comment Syntax Detection)
+
+## Purpose
+Define language detection and comment syntax mapping capabilities to enable marker detection across all major programming languages.
+
+## ADDED Requirements
+
+### Requirement: Language Detection by File Extension
+The system SHALL detect programming languages based on file extensions with high accuracy for common languages.
+
+#### Scenario: Go file detection
+- **WHEN** a file has extension `.go`
+- **THEN** the system SHALL detect language as Go
+- **AND** use `//` as the comment pattern
+
+#### Scenario: Python file detection
+- **WHEN** a file has extension `.py`
+- **THEN** the system SHALL detect language as Python
+- **AND** use `#` as the comment pattern
+
+#### Scenario: JavaScript file detection
+- **WHEN** a file has extension `.js` or `.jsx`
+- **THEN** the system SHALL detect language as JavaScript
+- **AND** use `//` as the comment pattern
+
+#### Scenario: TypeScript file detection
+- **WHEN** a file has extension `.ts` or `.tsx`
+- **THEN** the system SHALL detect language as TypeScript
+- **AND** use `//` as the comment pattern
+
+#### Scenario: Rust file detection
+- **WHEN** a file has extension `.rs`
+- **THEN** the system SHALL detect language as Rust
+- **AND** use `//` as the comment pattern
+
+#### Scenario: Java file detection
+- **WHEN** a file has extension `.java`
+- **THEN** the system SHALL detect language as Java
+- **AND** use `//` as the comment pattern
+
+#### Scenario: C file detection
+- **WHEN** a file has extension `.c` or `.h`
+- **THEN** the system SHALL detect language as C
+- **AND** use `//` as the primary comment pattern
+
+#### Scenario: C++ file detection
+- **WHEN** a file has extension `.cpp`, `.cc`, `.hpp`, or `.cxx`
+- **THEN** the system SHALL detect language as C++
+- **AND** use `//` as the primary comment pattern
+
+#### Scenario: Ruby file detection
+- **WHEN** a file has extension `.rb`
+- **THEN** the system SHALL detect language as Ruby
+- **AND** use `#` as the comment pattern
+
+#### Scenario: PHP file detection
+- **WHEN** a file has extension `.php`
+- **THEN** the system SHALL detect language as PHP
+- **AND** use `//` and `#` as comment patterns
+
+#### Scenario: Shell script detection
+- **WHEN** a file has extension `.sh`, `.bash`, or `.zsh`
+- **THEN** the system SHALL detect language as Shell
+- **AND** use `#` as the comment pattern
+
+### Requirement: Unknown Language Fallback
+The system SHALL provide fallback behavior for files with unknown or uncommon extensions.
+
+#### Scenario: Unknown extension fallback
+- **WHEN** a file has an unrecognized extension (e.g., `.xyz`)
+- **THEN** the system SHALL attempt detection using all common comment patterns
+- **AND** try patterns in order: `//`, `#`, `/*`
+
+#### Scenario: No extension fallback
+- **WHEN** a file has no extension (e.g., `Makefile`, `Dockerfile`)
+- **THEN** the system SHALL attempt detection using all common comment patterns
+- **AND** successfully find markers if they exist in any comment style
+
+### Requirement: Comment Pattern Mapping
+The system SHALL correctly map detected languages to their respective comment syntax patterns.
+
+#### Scenario: Double-slash comment languages
+- **WHEN** the language is Go, Rust, JavaScript, TypeScript, Java, C, or C++
+- **THEN** the system SHALL use `//` as the line comment pattern
+- **AND** markers in lines starting with `//` SHALL be detected
+
+#### Scenario: Hash comment languages
+- **WHEN** the language is Python, Ruby, or Shell
+- **THEN** the system SHALL use `#` as the line comment pattern
+- **AND** markers in lines starting with `#` SHALL be detected
+
+#### Scenario: Multi-pattern languages
+- **WHEN** the language supports multiple comment styles (e.g., C, PHP)
+- **THEN** the system SHALL try all applicable patterns
+- **AND** detect markers in any valid comment syntax
+
+### Requirement: Marker Pattern Matching in Comments
+The system SHALL correctly identify markers within language-specific comments, ignoring markers in strings or non-comment contexts.
+
+#### Scenario: Marker in line comment
+- **WHEN** a line contains `// <!-- conclaude-uneditable:start -->`
+- **AND** the language uses `//` comments
+- **THEN** the marker SHALL be detected
+
+#### Scenario: Marker with leading whitespace
+- **WHEN** a line contains `   // <!-- conclaude-uneditable:start -->` (indented)
+- **AND** the language uses `//` comments
+- **THEN** the marker SHALL be detected
+
+#### Scenario: Marker with trailing content
+- **WHEN** a line contains `// <!-- conclaude-uneditable:start --> - do not modify`
+- **AND** the language uses `//` comments
+- **THEN** the marker SHALL be detected
+
+#### Scenario: Marker in string literal (should ignore)
+- **WHEN** a line contains `const x = "<!-- conclaude-uneditable:start -->"` (in a string)
+- **AND** the line does not start with a comment pattern
+- **THEN** the marker SHALL NOT be detected
+- **AND** the line SHALL be treated as regular code
+
+#### Scenario: Marker in multi-line string (should ignore)
+- **WHEN** content contains markers within triple-quoted strings (Python) or template literals (JS)
+- **AND** the markers are not in actual comments
+- **THEN** the markers SHALL NOT be detected
+
+### Requirement: Case Sensitivity
+The system SHALL use case-sensitive matching for marker detection to ensure consistency.
+
+#### Scenario: Correct case marker
+- **WHEN** a comment contains `<!-- conclaude-uneditable:start -->` (lowercase)
+- **THEN** the marker SHALL be detected
+
+#### Scenario: Incorrect case marker
+- **WHEN** a comment contains `<!-- CONCLAUDE-UNEDITABLE:START -->` (uppercase)
+- **THEN** the marker SHALL NOT be detected
+- **AND** no protected range SHALL be created
+
+### Requirement: Whitespace Handling
+The system SHALL handle various whitespace configurations around markers.
+
+#### Scenario: Marker with spaces
+- **WHEN** a comment contains `//  <!-- conclaude-uneditable:start -->` (extra spaces)
+- **THEN** the marker SHALL be detected
+
+#### Scenario: Marker with tabs
+- **WHEN** a comment contains `//\t<!-- conclaude-uneditable:start -->` (tab character)
+- **THEN** the marker SHALL be detected
+
+#### Scenario: Indented marker
+- **WHEN** a marker line is indented to match code indentation
+- **THEN** the marker SHALL be detected regardless of indentation level
+
+### Requirement: Special File Types
+The system SHALL support special file types that may not have standard extensions.
+
+#### Scenario: Markdown files
+- **WHEN** a file has extension `.md`
+- **THEN** markers in HTML comments SHALL be detected
+- **AND** `<!-- conclaude-uneditable:start -->` SHALL work natively
+
+#### Scenario: HTML/XML files
+- **WHEN** a file has extension `.html`, `.xml`, or `.svg`
+- **THEN** markers in HTML comments SHALL be detected
+- **AND** `<!-- conclaude-uneditable:start -->` SHALL work natively
+
+#### Scenario: YAML files
+- **WHEN** a file has extension `.yaml` or `.yml`
+- **THEN** the system SHALL use `#` as the comment pattern
+- **AND** markers SHALL be detected in lines starting with `#`
+
+#### Scenario: JSON files
+- **WHEN** a file has extension `.json`
+- **THEN** the system SHALL NOT support markers (JSON has no comment syntax)
+- **AND** return an empty protected ranges list
+
+### Requirement: Language-Agnostic Marker Format
+The system SHALL use a consistent marker format (`<!-- conclaude-uneditable:start/end -->`) across all languages, embedded in language-specific comments.
+
+#### Scenario: Same marker in different languages
+- **WHEN** the marker `<!-- conclaude-uneditable:start -->` is used in Go (`//`), Python (`#`), and HTML
+- **THEN** the marker SHALL be detected in all three languages
+- **AND** the marker format SHALL be identical in all cases
+
+#### Scenario: Marker format consistency
+- **WHEN** developers copy markers between different language files
+- **THEN** the markers SHALL work without modification
+- **AND** only the surrounding comment syntax SHALL differ
+
+### Requirement: Performance Across Languages
+The system SHALL efficiently detect markers across all supported languages with consistent performance.
+
+#### Scenario: Language detection overhead
+- **WHEN** detecting language for any file
+- **THEN** detection SHALL complete in under 1ms
+- **AND** add negligible overhead to marker parsing
+
+#### Scenario: Pattern matching overhead
+- **WHEN** scanning for markers using language-specific patterns
+- **THEN** performance SHALL be equivalent across all languages
+- **AND** no language SHALL have significantly slower marker detection
+
+### Requirement: Error Handling for Unsupported Scenarios
+The system SHALL gracefully handle scenarios where marker detection is not possible or meaningful.
+
+#### Scenario: Binary file
+- **WHEN** a file is detected as binary (e.g., `.png`, `.exe`)
+- **THEN** marker detection SHALL be skipped
+- **AND** an empty protected ranges list SHALL be returned
+- **AND** no errors SHALL be raised
+
+#### Scenario: Empty file
+- **WHEN** a file is empty (0 bytes)
+- **THEN** marker detection SHALL return empty protected ranges
+- **AND** no errors SHALL be raised
+
+#### Scenario: File read error
+- **WHEN** a file cannot be read (permissions, not found, etc.)
+- **THEN** marker detection SHALL propagate the error
+- **AND** the PreToolUse hook SHALL fail with a clear error message

--- a/spectr/changes/add-uneditable-markers/specs/validation-rules/spec.md
+++ b/spectr/changes/add-uneditable-markers/specs/validation-rules/spec.md
@@ -1,0 +1,184 @@
+# Specification: Validation Rules (Uneditable Markers)
+
+## Purpose
+Define validation rules for detecting and enforcing uneditable code range markers in source files, protecting specific line ranges from modification by Claude Code.
+
+## ADDED Requirements
+
+### Requirement: Marker Detection in Files
+The system SHALL detect `conclaude-uneditable` markers embedded in source code comments across all file types.
+
+#### Scenario: Markers present in file
+- **WHEN** a file contains `<!-- conclaude-uneditable:start -->` and `<!-- conclaude-uneditable:end -->` markers in comments
+- **THEN** the system SHALL extract the protected line ranges
+- **AND** the ranges SHALL include the marker lines themselves (inclusive)
+
+#### Scenario: No markers in file
+- **WHEN** a file does not contain any `conclaude-uneditable` markers
+- **THEN** the system SHALL return an empty list of protected ranges
+- **AND** no validation errors SHALL be raised
+
+#### Scenario: Multiple protected ranges in single file
+- **WHEN** a file contains multiple pairs of start/end markers
+- **THEN** the system SHALL extract all protected ranges independently
+- **AND** each range SHALL be validated separately
+
+### Requirement: Protected Range Extraction
+The system SHALL extract protected line ranges from detected markers and represent them with start and end line numbers (1-indexed, inclusive).
+
+#### Scenario: Simple protected range
+- **WHEN** markers are on lines 10 and 15
+- **THEN** the protected range SHALL be lines 10-15 (inclusive)
+- **AND** any edit touching lines 10-15 SHALL be blocked
+
+#### Scenario: Single-line range
+- **WHEN** start and end markers are on consecutive lines (e.g., lines 5 and 6)
+- **THEN** the protected range SHALL be lines 5-6
+- **AND** the range SHALL be valid and enforced
+
+#### Scenario: Large range
+- **WHEN** markers span hundreds of lines (e.g., lines 1 and 500)
+- **THEN** the system SHALL extract the range correctly
+- **AND** performance SHALL remain acceptable (< 10ms parsing time)
+
+### Requirement: Edit Operation Validation
+The system SHALL validate `Edit` and `Write` operations against protected ranges and block operations that overlap with protected code.
+
+#### Scenario: Edit overlaps protected range
+- **WHEN** an `Edit` operation targets lines 12-14
+- **AND** a protected range is lines 10-20
+- **THEN** the system SHALL block the operation
+- **AND** return a clear error message indicating the protected range
+
+#### Scenario: Edit outside protected range
+- **WHEN** an `Edit` operation targets lines 5-8
+- **AND** a protected range is lines 10-20
+- **THEN** the system SHALL allow the operation
+- **AND** no error SHALL be returned
+
+#### Scenario: Edit partially overlaps start of range
+- **WHEN** an `Edit` operation targets lines 8-12
+- **AND** a protected range is lines 10-20
+- **THEN** the system SHALL block the operation
+- **AND** indicate that lines 10-12 are protected
+
+#### Scenario: Edit partially overlaps end of range
+- **WHEN** an `Edit` operation targets lines 18-22
+- **AND** a protected range is lines 10-20
+- **THEN** the system SHALL block the operation
+- **AND** indicate that lines 18-20 are protected
+
+#### Scenario: Edit fully contains protected range
+- **WHEN** an `Edit` operation targets lines 5-25
+- **AND** a protected range is lines 10-20
+- **THEN** the system SHALL block the operation
+- **AND** indicate the protected range is within the edit scope
+
+#### Scenario: Edit is fully contained by protected range
+- **WHEN** an `Edit` operation targets lines 12-15
+- **AND** a protected range is lines 10-20
+- **THEN** the system SHALL block the operation
+- **AND** indicate the entire edit is within protected range
+
+### Requirement: Write Operation Validation
+The system SHALL block `Write` operations that would overwrite files containing protected ranges.
+
+#### Scenario: Write to file with protected ranges
+- **WHEN** a `Write` operation targets a file
+- **AND** the file already exists with protected ranges
+- **THEN** the system SHALL block the operation
+- **AND** indicate which protected ranges would be affected
+
+#### Scenario: Write to new file
+- **WHEN** a `Write` operation creates a new file
+- **AND** the file does not yet exist
+- **THEN** the system SHALL allow the operation
+- **AND** no marker validation SHALL be performed
+
+### Requirement: Marker Pairing Validation
+The system SHALL validate that markers are properly paired and report errors for malformed marker structures.
+
+#### Scenario: Unclosed start marker
+- **WHEN** a file contains `<!-- conclaude-uneditable:start -->` without a matching end marker
+- **THEN** the system SHALL return a validation error
+- **AND** block ALL edit operations on the file
+- **AND** indicate the line number of the unclosed marker
+
+#### Scenario: Unmatched end marker
+- **WHEN** a file contains `<!-- conclaude-uneditable:end -->` without a preceding start marker
+- **THEN** the system SHALL return a validation error
+- **AND** block ALL edit operations on the file
+- **AND** indicate the line number of the unmatched marker
+
+#### Scenario: Properly paired markers
+- **WHEN** all start markers have matching end markers in correct order
+- **THEN** the system SHALL successfully extract protected ranges
+- **AND** no validation errors SHALL be raised
+
+### Requirement: Nested Marker Detection
+The system SHALL detect nested or overlapping markers and report them as errors.
+
+#### Scenario: Nested markers
+- **WHEN** a file contains start-start-end-end marker sequence
+- **THEN** the system SHALL return a validation error
+- **AND** block ALL edit operations on the file
+- **AND** indicate the line numbers of conflicting markers
+
+#### Scenario: Overlapping markers
+- **WHEN** marker ranges overlap (e.g., 1-10 and 5-15)
+- **THEN** the system SHALL return a validation error
+- **AND** indicate the line numbers of overlapping ranges
+
+### Requirement: Error Message Clarity
+The system SHALL provide clear, actionable error messages when blocking operations due to protected ranges.
+
+#### Scenario: Blocked edit error message
+- **WHEN** an edit is blocked due to protected range overlap
+- **THEN** the error message SHALL include:
+  - The operation type (Edit/Write)
+  - The protected line range (start-end)
+  - The file path
+  - Indication that markers are present
+
+#### Scenario: Malformed marker error message
+- **WHEN** markers are malformed (unclosed, nested, etc.)
+- **THEN** the error message SHALL include:
+  - The specific error (unclosed/unmatched/nested)
+  - The line number(s) involved
+  - Guidance on how to fix the issue
+
+### Requirement: Performance Requirements
+The system SHALL efficiently detect and validate markers with minimal performance impact on hook execution.
+
+#### Scenario: Small file parsing
+- **WHEN** parsing a file under 1000 lines
+- **THEN** marker detection SHALL complete in under 5ms
+
+#### Scenario: Large file parsing
+- **WHEN** parsing a file between 1000-10000 lines
+- **THEN** marker detection SHALL complete in under 10ms
+
+#### Scenario: Very large file parsing
+- **WHEN** parsing a file over 10000 lines
+- **THEN** marker detection SHALL complete in under 50ms
+- **AND** not block other hook operations
+
+### Requirement: PreToolUse Hook Integration
+The system SHALL integrate marker validation into the existing PreToolUse hook workflow without breaking existing functionality.
+
+#### Scenario: Integration with existing rules
+- **WHEN** both `uneditableFiles` glob patterns and marker-based protection are configured
+- **THEN** both SHALL be enforced independently
+- **AND** if either blocks an operation, the operation SHALL be blocked
+- **AND** the most specific error message SHALL be returned
+
+#### Scenario: Marker validation before tool execution
+- **WHEN** a PreToolUse hook is triggered for Edit/Write operations
+- **THEN** marker validation SHALL occur before the tool executes
+- **AND** blocked operations SHALL never reach the tool
+- **AND** allowed operations SHALL proceed normally
+
+#### Scenario: Non-Edit/Write tools unaffected
+- **WHEN** a PreToolUse hook is triggered for tools other than Edit/Write (e.g., Read, Bash)
+- **THEN** marker validation SHALL be skipped
+- **AND** performance SHALL not be impacted

--- a/spectr/changes/add-uneditable-markers/tasks.md
+++ b/spectr/changes/add-uneditable-markers/tasks.md
@@ -1,0 +1,174 @@
+# Implementation Tasks: Uneditable Code Range Markers
+
+## 1. Core Module Setup
+
+- [ ] 1.1 Create new module `src/markers.rs`
+- [ ] 1.2 Add module declaration to `src/lib.rs`
+- [ ] 1.3 Define `ProtectedRange` struct with start_line, end_line, and optional reason
+- [ ] 1.4 Define `Language` enum for supported languages
+- [ ] 1.5 Define `CommentPattern` enum for comment syntax types
+
+## 2. Language Detection Implementation
+
+- [ ] 2.1 Implement `detect_language(file_path: &Path) -> Language` function
+- [ ] 2.2 Add extension mapping for core languages (Go, Python, JS, TS, Rust, Java)
+- [ ] 2.3 Add extension mapping for additional languages (C, C++, Ruby, PHP, Shell)
+- [ ] 2.4 Add extension mapping for special file types (HTML, Markdown, YAML)
+- [ ] 2.5 Implement fallback logic for unknown extensions
+- [ ] 2.6 Write unit tests for language detection (all supported extensions)
+
+## 3. Comment Pattern Mapping
+
+- [ ] 3.1 Implement `get_comment_patterns(language: Language) -> Vec<&'static str>` function
+- [ ] 3.2 Map double-slash languages (`//`: Go, Rust, JS, TS, Java, C++, C)
+- [ ] 3.3 Map hash languages (`#`: Python, Ruby, Shell, YAML)
+- [ ] 3.4 Map HTML-comment languages (`<!--`: HTML, Markdown, XML)
+- [ ] 3.5 Map multi-pattern languages (C: both `//` and `/*`, PHP: both `//` and `#`)
+- [ ] 3.6 Write unit tests for comment pattern mapping
+
+## 4. Marker Detection Implementation
+
+- [ ] 4.1 Implement `extract_protected_ranges(content: &str, patterns: &[&str]) -> Result<Vec<ProtectedRange>>` function
+- [ ] 4.2 Implement line-by-line scanning with comment pattern matching
+- [ ] 4.3 Detect `<!-- conclaude-uneditable:start -->` markers
+- [ ] 4.4 Detect `<!-- conclaude-uneditable:end -->` markers
+- [ ] 4.5 Build protected range from matched start/end pairs (inclusive of marker lines)
+- [ ] 4.6 Implement stack-based tracking for marker pairing
+- [ ] 4.7 Detect and error on unclosed start markers
+- [ ] 4.8 Detect and error on unmatched end markers
+- [ ] 4.9 Detect and error on nested markers (start-start-end-end)
+- [ ] 4.10 Write unit tests for marker detection (valid, invalid, edge cases)
+
+## 5. Range Validation Logic
+
+- [ ] 5.1 Implement `has_overlap(edit_start: usize, edit_end: usize, protected: &ProtectedRange) -> bool` function
+- [ ] 5.2 Handle overlap when edit starts inside range
+- [ ] 5.3 Handle overlap when edit ends inside range
+- [ ] 5.4 Handle overlap when edit fully contains range
+- [ ] 5.5 Handle overlap when edit is fully contained by range
+- [ ] 5.6 Handle no overlap cases (edit before or after range)
+- [ ] 5.7 Write unit tests for overlap detection (all scenarios)
+
+## 6. Edit Range Extraction from Payloads
+
+- [ ] 6.1 Implement `extract_file_path(payload: &PreToolUsePayload) -> Result<PathBuf>` function
+- [ ] 6.2 Handle `Edit` tool payload file path extraction
+- [ ] 6.3 Handle `Write` tool payload file path extraction
+- [ ] 6.4 Implement `extract_edit_range(payload: &PreToolUsePayload) -> Result<(usize, usize)>` function
+- [ ] 6.5 Parse `Edit` tool parameters for start/end line numbers
+- [ ] 6.6 Handle `Write` tool as full-file edit (lines 1 to EOF)
+- [ ] 6.7 Write unit tests for payload parsing
+
+## 7. PreToolUse Hook Integration
+
+- [ ] 7.1 Add `check_uneditable_markers(payload, config_dir) -> Result<Option<String>>` function to `hooks.rs`
+- [ ] 7.2 Call marker check in `handle_pre_tool_use` for `Edit` and `Write` tools only
+- [ ] 7.3 Skip marker check for other tools (Read, Bash, etc.)
+- [ ] 7.4 Read target file content
+- [ ] 7.5 Detect language from file path
+- [ ] 7.6 Get comment patterns for language
+- [ ] 7.7 Extract protected ranges from file
+- [ ] 7.8 Extract edit range from payload
+- [ ] 7.9 Check for overlap between edit and protected ranges
+- [ ] 7.10 Return blocked result with clear error message if overlap detected
+- [ ] 7.11 Return allowed result if no overlap
+- [ ] 7.12 Handle errors (file read failures, malformed markers, etc.)
+
+## 8. Error Message Implementation
+
+- [ ] 8.1 Implement clear error message for blocked edits (include line numbers, file path)
+- [ ] 8.2 Implement error message for unclosed markers (include line number)
+- [ ] 8.3 Implement error message for unmatched end markers (include line number)
+- [ ] 8.4 Implement error message for nested markers (include line numbers)
+- [ ] 8.5 Ensure error messages are actionable and guide users to fix issues
+
+## 9. Unit Tests
+
+- [ ] 9.1 Test marker detection in Go files (`//` comments)
+- [ ] 9.2 Test marker detection in Python files (`#` comments)
+- [ ] 9.3 Test marker detection in JavaScript/TypeScript files (`//` comments)
+- [ ] 9.4 Test marker detection in Rust files (`//` comments)
+- [ ] 9.5 Test marker detection in Java files (`//` comments)
+- [ ] 9.6 Test marker detection in C/C++ files (`//` comments)
+- [ ] 9.7 Test marker detection in Ruby files (`#` comments)
+- [ ] 9.8 Test marker detection in Shell files (`#` comments)
+- [ ] 9.9 Test marker detection in HTML/Markdown files (native `<!--` comments)
+- [ ] 9.10 Test marker detection in YAML files (`#` comments)
+- [ ] 9.11 Test multiple protected ranges in same file
+- [ ] 9.12 Test unclosed marker error
+- [ ] 9.13 Test unmatched end marker error
+- [ ] 9.14 Test nested marker error
+- [ ] 9.15 Test empty file (no markers)
+- [ ] 9.16 Test file with no markers
+- [ ] 9.17 Test overlap detection (all scenarios)
+- [ ] 9.18 Test edit allowed (no overlap)
+- [ ] 9.19 Test unknown file extension fallback
+
+## 10. Integration Tests
+
+- [ ] 10.1 Test PreToolUse hook blocks Edit operation touching protected range
+- [ ] 10.2 Test PreToolUse hook allows Edit operation outside protected range
+- [ ] 10.3 Test PreToolUse hook blocks Write operation overwriting protected file
+- [ ] 10.4 Test PreToolUse hook allows Write operation for new files (no markers)
+- [ ] 10.5 Test error message clarity for blocked operations
+- [ ] 10.6 Test error message clarity for malformed markers
+- [ ] 10.7 Test interaction with existing `uneditableFiles` glob patterns (both enforced independently)
+- [ ] 10.8 Test performance on small files (< 1000 lines, < 5ms)
+- [ ] 10.9 Test performance on medium files (1000-5000 lines, < 10ms)
+- [ ] 10.10 Test performance on large files (5000-10000 lines, < 50ms)
+
+## 11. Edge Case Handling
+
+- [ ] 11.1 Handle binary files gracefully (skip marker detection)
+- [ ] 11.2 Handle empty files (return empty protected ranges)
+- [ ] 11.3 Handle files with only markers (no other content)
+- [ ] 11.4 Handle markers in string literals (should not be detected)
+- [ ] 11.5 Handle markers with extra whitespace (should be detected)
+- [ ] 11.6 Handle markers with tabs (should be detected)
+- [ ] 11.7 Handle deeply indented markers (should be detected)
+- [ ] 11.8 Handle file read errors (propagate error clearly)
+- [ ] 11.9 Handle JSON files (no comment syntax, skip marker detection)
+
+## 12. Documentation
+
+- [ ] 12.1 Add documentation to `markers.rs` module
+- [ ] 12.2 Add function-level documentation for all public functions
+- [ ] 12.3 Update `README.md` with marker feature explanation
+- [ ] 12.4 Add examples for major languages (Go, Python, JS, Rust, etc.)
+- [ ] 12.5 Document marker format and usage guidelines
+- [ ] 12.6 Document error messages and how to resolve them
+- [ ] 12.7 Add FAQ section for common questions (nested markers, custom formats, etc.)
+
+## 13. Performance Optimization (if needed)
+
+- [ ] 13.1 Benchmark marker detection on typical codebases
+- [ ] 13.2 Profile performance on large files
+- [ ] 13.3 Optimize if benchmarks show > 10ms average overhead
+- [ ] 13.4 Consider early-exit optimizations (stop after finding relevant range)
+- [ ] 13.5 Consider caching marker positions (future enhancement)
+
+## 14. Final Validation
+
+- [ ] 14.1 Run all unit tests (`cargo test`)
+- [ ] 14.2 Run all integration tests
+- [ ] 14.3 Run clippy lints (`cargo clippy`)
+- [ ] 14.4 Run rustfmt (`cargo fmt`)
+- [ ] 14.5 Test manually with real codebases (Go, Python, JS, Rust)
+- [ ] 14.6 Verify error messages are clear and actionable
+- [ ] 14.7 Verify performance is acceptable (< 10ms on typical files)
+- [ ] 14.8 Update schema if configuration added (`cargo run --bin generate-schema`)
+- [ ] 14.9 Run spectr validation if available (`spectr validate --strict`)
+
+## Dependencies
+
+- No external dependencies required (uses existing `glob`, `serde`, `anyhow`)
+- Tasks 1-5 can be developed in parallel with tasks 6-7
+- Tasks 8-11 depend on tasks 1-7 being complete
+- Tasks 12-14 are final polish and validation
+
+## Estimated Complexity
+
+- **Core implementation (tasks 1-7):** Medium complexity, ~300-400 LOC
+- **Testing (tasks 9-11):** High coverage needed, ~500-600 LOC
+- **Documentation (task 12):** Moderate effort, clear examples needed
+- **Total estimated effort:** Medium-large feature (2-3 days of focused work)


### PR DESCRIPTION
Create comprehensive Spectr proposal for in-code uneditable range markers that protect specific line ranges from modification across all programming languages.

Key features:
- Language-agnostic marker syntax embedded in comments
- Support for 11+ major programming languages
- Automatic detection with no configuration required
- Clear error messages for blocked operations
- Performance optimized (<10ms overhead)

Includes:
- proposal.md with problem statement and feature description
- design.md with technical architecture and design decisions
- tasks.md with 100+ implementation tasks
- Two new capability specs (validation-rules, language-support)
  - 19 total requirements
  - 64 detailed scenarios

Related capabilities: validation-rules (new), language-support (new)