### PR TITLE
fix: read version from Cargo.toml in flake.nix

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -24,6 +24,9 @@
       };
       craneLib = (crane.mkLib pkgs).overrideToolchain (p: p.rust-bin.stable.latest.default);
 
+      cargoToml = builtins.fromTOML (builtins.readFile ./Cargo.toml);
+      version = cargoToml.package.version;
+
       src = pkgs.lib.cleanSourceWith {
         src = ./.;
         filter = path: type:
@@ -33,10 +36,9 @@
       };
 
       conclaude = craneLib.buildPackage {
-        inherit src;
+        inherit src version;
         strictDeps = true;
         pname = "conclaude";
-        version = "0.1.2";
       };
 
       rooted = exec:


### PR DESCRIPTION
## Summary
- Read package version from Cargo.toml using `builtins.fromTOML` instead of hardcoding
- Fixes version mismatch (flake had 0.1.2, Cargo.toml has 0.2.1)
- Ensures Nix package version stays in sync with Cargo.toml automatically

## Test plan
- [x] Run `nix build` to verify the flake still builds correctly
- [x] Check that the built package has the correct version from Cargo.toml

🤖 Generated with [Claude Code](https://claude.com/claude-code)