### PR TITLE
fix: make matcher field optional in ClaudeHookMatcher

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -138,6 +138,7 @@ struct ClaudeHookConfig {
 
 #[derive(serde::Serialize, serde::Deserialize)]
 struct ClaudeHookMatcher {
+    #[serde(default)]
     matcher: String,
     hooks: Vec<ClaudeHookConfig>,
 }


### PR DESCRIPTION
## Summary
- Fixes init command failing when parsing existing settings.json files that have hooks without the `matcher` field
- Adds `#[serde(default)]` to the `matcher` field in `ClaudeHookMatcher` struct so it defaults to an empty string when missing

## Problem
When running `conclaude init --force`, the command failed with:
```
Error: Failed to parse settings file: .claude/settings.json

Caused by:
    missing field `matcher` at line 92 column 7
```

This occurred because the `Stop` hook (created by Claude Code itself) didn't include the `matcher` field, while our parser required it.

## Test plan
- [x] Verified `conclaude init --force` now succeeds with existing settings.json
- [x] All existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of incomplete configurations to ensure graceful default value assignment when optional fields are missing.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->