### PR TITLE
spectr(proposal): fix-command-working-directory

### DIFF
--- a/spectr/changes/fix-command-working-directory/proposal.md
+++ b/spectr/changes/fix-command-working-directory/proposal.md
@@ -1,0 +1,21 @@
+# Change: Fix Command Working Directory to Use Config File Directory
+
+## Why
+
+Commands defined in `.conclaude.yaml` configuration files currently execute with the working directory set to Claude's session directory (wherever Claude Code is invoked from), rather than the directory containing the configuration file. This causes commands like `npm test` or `cargo build` to fail when the configuration file is located in a parent directory, as they run from the wrong project context.
+
+## What Changes
+
+- **Execution behavior**: All configured commands (`stop.commands`, `subagentStop.commands`) SHALL execute with their current working directory set to the parent directory of the configuration file
+- **Environment variable**: Commands SHALL receive `CONCLAUDE_CONFIG_DIR` environment variable pointing to the config file's parent directory
+- **Config path propagation**: The configuration file path must be passed through to command execution functions
+- **Function signature updates**: `execute_stop_commands` and `execute_subagent_stop_commands` will accept the config directory path as a parameter
+- **TokioCommand enhancement**: Add `.current_dir()` and `.env("CONCLAUDE_CONFIG_DIR", ...)` to all command spawning calls
+- **No additional logging**: Working directory changes will NOT be logged (minimal output preferred)
+
+## Impact
+
+- Affected specs: `execution`
+- Affected code: `src/hooks.rs` (command execution functions)
+- Breaking change: **No** - this fixes incorrect behavior; commands will now run from the expected directory
+- Backward compatibility: Commands that previously worked by coincidence (config in same dir as session) continue to work

--- a/spectr/changes/fix-command-working-directory/specs/execution/spec.md
+++ b/spectr/changes/fix-command-working-directory/specs/execution/spec.md
@@ -1,0 +1,53 @@
+## ADDED Requirements
+
+### Requirement: Command Working Directory
+
+The system SHALL execute all configured commands with the current working directory set to the directory containing the configuration file, not the directory from which Claude Code was invoked.
+
+#### Scenario: Stop command executes from config directory
+
+- **WHEN** a stop command is configured in `.conclaude.yaml` located at `/home/user/project/.conclaude.yaml`
+- **AND** Claude Code session runs from `/home/user/project/src/nested`
+- **THEN** the stop command SHALL execute with cwd set to `/home/user/project/`
+- **AND** relative paths in commands like `npm test` SHALL resolve from `/home/user/project/`
+
+#### Scenario: Subagent stop command executes from config directory
+
+- **WHEN** a subagent stop command is configured in `.conclaude.yaml` located at `/home/user/project/.conclaude.yaml`
+- **AND** Claude Code session runs from `/home/user/project/deep/nested/dir`
+- **THEN** the subagent stop command SHALL execute with cwd set to `/home/user/project/`
+- **AND** the command SHALL have access to project files relative to the config location
+
+#### Scenario: Config in current directory
+
+- **WHEN** the configuration file is in the same directory as the Claude Code session
+- **THEN** commands SHALL execute from that directory
+- **AND** behavior SHALL be identical to previous implementation for this case
+
+#### Scenario: Commands with absolute paths
+
+- **WHEN** a command uses an absolute path (e.g., `/usr/bin/custom-linter`)
+- **THEN** the command SHALL execute successfully regardless of working directory
+- **AND** the working directory SHALL still be set to the config directory
+
+### Requirement: Config Directory Environment Variable
+
+The system SHALL expose the configuration file's parent directory as an environment variable to all executed commands.
+
+#### Scenario: CONCLAUDE_CONFIG_DIR available to stop commands
+
+- **WHEN** a stop command executes
+- **THEN** the environment variable `CONCLAUDE_CONFIG_DIR` SHALL be set
+- **AND** its value SHALL be the absolute path to the directory containing `.conclaude.yaml`
+
+#### Scenario: CONCLAUDE_CONFIG_DIR available to subagent stop commands
+
+- **WHEN** a subagent stop command executes
+- **THEN** the environment variable `CONCLAUDE_CONFIG_DIR` SHALL be set
+- **AND** its value SHALL be the absolute path to the directory containing `.conclaude.yaml`
+
+#### Scenario: Script uses CONCLAUDE_CONFIG_DIR
+
+- **WHEN** a command script references `$CONCLAUDE_CONFIG_DIR`
+- **THEN** it SHALL resolve to the config file's parent directory
+- **AND** the script MAY use it for explicit path construction (e.g., `$CONCLAUDE_CONFIG_DIR/scripts/lint.sh`)

--- a/spectr/changes/fix-command-working-directory/tasks.md
+++ b/spectr/changes/fix-command-working-directory/tasks.md
@@ -1,0 +1,23 @@
+## 1. Implementation
+
+- [ ] 1.1 Update `execute_stop_commands` function signature to accept `config_dir: &Path` parameter
+- [ ] 1.2 Add `.current_dir(config_dir)` to the `TokioCommand` in `execute_stop_commands`
+- [ ] 1.3 Add `.env("CONCLAUDE_CONFIG_DIR", config_dir)` to the `TokioCommand` in `execute_stop_commands`
+- [ ] 1.4 Update `execute_subagent_stop_commands` function signature to accept `config_dir: &Path` parameter
+- [ ] 1.5 Add `.current_dir(config_dir)` to the `TokioCommand` in `execute_subagent_stop_commands`
+- [ ] 1.6 Update `build_subagent_env_vars` to accept `config_dir: &Path` and add `CONCLAUDE_CONFIG_DIR` to the HashMap
+- [ ] 1.7 Update `handle_stop` to extract config directory from `config_path` and pass to `execute_stop_commands`
+- [ ] 1.8 Update `handle_subagent_stop` to extract config directory from `config_path`, pass to `build_subagent_env_vars` and `execute_subagent_stop_commands`
+
+## 2. Testing
+
+- [ ] 2.1 Add unit test verifying commands receive correct working directory
+- [ ] 2.2 Add unit test verifying `CONCLAUDE_CONFIG_DIR` environment variable is set correctly
+- [ ] 2.3 Add integration test with config file in parent directory
+- [ ] 2.4 Verify existing tests still pass with `cargo test`
+
+## 3. Validation
+
+- [ ] 3.1 Run `cargo clippy` to ensure no new warnings
+- [ ] 3.2 Run `cargo fmt --check` to ensure formatting
+- [ ] 3.3 Manual verification: run conclaude from subdirectory with config in parent


### PR DESCRIPTION
Proposal for review: spectr/changes/fix-command-working-directory/

Generated by: spectr pr proposal

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Commands now execute from the configuration file's parent directory instead of the session directory, improving relative path handling.
  * New `CONCLAUDE_CONFIG_DIR` environment variable now available to all executed commands, allowing scripts to reference the configuration directory.

* **Documentation**
  * Added specifications and implementation tasks documenting command execution working directory behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->