### PR TITLE
spectr(apply): add-git-block-example

### DIFF
--- a/spectr/changes/add-git-block-example/proposal.md
+++ b/spectr/changes/add-git-block-example/proposal.md
@@ -1,0 +1,36 @@
+# Add Git Command Blocking Example to Default Configuration
+
+## Why
+
+The default configuration file (`src/default-config.yaml`) provides comprehensive examples for most features but is missing a practical example of blocking git shell commands using `toolUsageValidation`. Users need guidance on how to prevent Claude Code from executing potentially dangerous git operations (like `git push --force`) or restrict git usage entirely. Adding this example addresses issue #111 and improves discoverability of this security feature.
+
+## What Changes
+
+- Add commented example to `toolUsageValidation` section in `src/default-config.yaml` showing how to block git commands
+- Include both specific command blocking (e.g., `git push --force*`) and wildcard git blocking examples
+- Follow existing documentation patterns with clear explanatory comments
+- Position the example logically within the existing `toolUsageValidation` examples section
+
+**Example to add:**
+```yaml
+# toolUsageValidation:
+#   # Block dangerous git force push operations
+#   - tool: "Bash"
+#     commandPattern: "git push --force*"
+#     action: "block"
+#     message: "Force push is not allowed - please use regular push"
+#
+#   # Block all git commands (uncomment to completely disable git via Bash tool)
+#   # - tool: "Bash"
+#   #   commandPattern: "git *"
+#   #   action: "block"
+#   #   message: "Git commands are not permitted in this session"
+```
+
+## Impact
+
+- **Affected specs**: configuration-defaults (documentation update)
+- **Affected code**: `src/default-config.yaml` (add commented examples)
+- **User experience**: Users can easily discover and copy examples for blocking git commands
+- **Documentation**: Improves completeness of default config documentation
+- **Security**: Helps users understand how to restrict git operations for safety

--- a/spectr/changes/add-git-block-example/specs/configuration-defaults/spec.md
+++ b/spectr/changes/add-git-block-example/specs/configuration-defaults/spec.md
@@ -1,0 +1,28 @@
+## ADDED Requirements
+
+### Requirement: Git Command Blocking Documentation
+
+The system SHALL include commented examples in the default configuration demonstrating how to block git shell commands using toolUsageValidation.
+
+#### Scenario: Default config includes git blocking example
+
+- **WHEN** viewing the default configuration file at `src/default-config.yaml`
+- **THEN** the `toolUsageValidation` examples section SHALL include a commented example blocking `git push --force*`
+- **AND** SHALL include a commented example blocking all git commands with pattern `git *`
+- **AND** SHALL include explanatory comments describing the security purpose of each example
+- **AND** SHALL follow the existing documentation style and formatting conventions
+
+#### Scenario: Examples use correct commandPattern syntax
+
+- **WHEN** a user views the git blocking examples in the default config
+- **THEN** each example SHALL use the `commandPattern` field for matching Bash commands
+- **AND** SHALL specify `tool: "Bash"` to target shell commands
+- **AND** SHALL include `action: "block"` to demonstrate blocking behavior
+- **AND** SHALL include descriptive `message` fields explaining why the command is blocked
+
+#### Scenario: Examples are positioned logically in config
+
+- **WHEN** a user navigates to the `toolUsageValidation` section
+- **THEN** the git command examples SHALL appear after existing file-based validation examples
+- **AND** SHALL maintain consistent YAML indentation with surrounding content
+- **AND** SHALL be clearly commented to indicate they are examples (not active rules)

--- a/spectr/changes/add-git-block-example/tasks.md
+++ b/spectr/changes/add-git-block-example/tasks.md
@@ -1,0 +1,13 @@
+## 1. Documentation Update
+
+- [x] 1.1 Locate the `toolUsageValidation` section in `src/default-config.yaml`
+- [x] 1.2 Add git command blocking examples after existing `toolUsageValidation` examples
+- [x] 1.3 Include both specific command pattern (git push --force) and wildcard pattern (git *)
+- [x] 1.4 Add clear explanatory comments following existing documentation style
+- [x] 1.5 Ensure YAML formatting and indentation matches surrounding examples
+
+## 2. Validation
+
+- [x] 2.1 Verify YAML syntax is valid with `conclaude validate --config src/default-config.yaml`
+- [x] 2.2 Confirm examples align with `extend-bash-command-validation` change documentation
+- [x] 2.3 Check that comments are clear and actionable for users

--- a/src/default-config.yaml
+++ b/src/default-config.yaml
@@ -150,6 +150,18 @@ preToolUse:
   #     pattern: ".env*"
   #     action: "block"
   #     message: "Environment files cannot be modified"
+  #
+  #   # Block dangerous git force push operations
+  #   - tool: "Bash"
+  #     commandPattern: "git push --force*"
+  #     action: "block"
+  #     message: "Force push is not allowed - please use regular push"
+  #
+  #   # Block all git commands (uncomment to completely disable git via Bash tool)
+  #   # - tool: "Bash"
+  #   #   commandPattern: "git *"
+  #   #   action: "block"
+  #   #   message: "Git commands are not permitted in this session"
 
   # Directories where file additions are prevented (in addition to root)
   # List of directory paths where new files cannot be created


### PR DESCRIPTION
## Summary
- Added git command blocking examples to `src/default-config.yaml`
- Provides users with practical examples for blocking dangerous git operations
- Includes example for blocking `git push --force*` commands
- Includes commented example for blocking all git commands via Bash tool
- Uses `commandPattern` field as specified in `extend-bash-command-validation` change

## Test plan
- [x] Validated YAML syntax with `conclaude validate --config-path src/default-config.yaml`
- [x] Confirmed examples align with `extend-bash-command-validation` proposal
- [x] Verified strict validation with `spectr validate add-git-block-example --strict`

Resolves issue #111

🤖 Generated with [Claude Code](https://claude.com/claude-code)