### PR TITLE
spectr(proposal): remove-generated-file-message

### DIFF
--- a/spectr/changes/remove-generated-file-message/proposal.md
+++ b/spectr/changes/remove-generated-file-message/proposal.md
@@ -1,0 +1,25 @@
+# Change: Remove generatedFileMessage Configuration Field
+
+## Why
+
+The `generatedFileMessage` field adds complexity for minimal value. It allows users to customize the error message when `preventGeneratedFileEdits` blocks a file operation, but the default message is already clear and informative. Removing this field simplifies the configuration surface and reduces maintenance overhead.
+
+## What Changes
+
+- **BREAKING**: Remove `generatedFileMessage` field from `preToolUse` configuration
+- Remove field from `PreToolUseConfig` struct in Rust code
+- Remove field from JSON schema
+- Remove field from default configuration
+- Update documentation to remove references
+- Simplify hook logic to always use the default message
+
+## Impact
+
+- Affected specs: `preToolUse`
+- Affected code:
+  - `src/config.rs` - Remove field from `PreToolUseConfig` struct and documentation
+  - `src/hooks.rs` - Remove custom message logic, always use default message
+  - `src/default-config.yaml` - Remove field
+  - `conclaude-schema.json` - Remove field from schema
+  - `docs/src/content/docs/reference/config/pre-tool-use.md` - Remove documentation
+  - `.conclaude.yaml` - Remove field from example config

--- a/spectr/changes/remove-generated-file-message/specs/preToolUse/spec.md
+++ b/spectr/changes/remove-generated-file-message/specs/preToolUse/spec.md
@@ -1,0 +1,17 @@
+## ADDED Requirements
+
+### Requirement: Reject Removed generatedFileMessage Field
+
+The system SHALL reject configuration containing the deprecated `generatedFileMessage` field, which has been removed from the preToolUse configuration schema.
+
+#### Scenario: Field rejected in configuration
+- **WHEN** a user provides `preToolUse.generatedFileMessage` in their configuration
+- **THEN** the configuration loading SHALL fail with a validation error
+- **AND** the error message SHALL indicate that `generatedFileMessage` is no longer a valid field
+
+#### Scenario: Default message used for generation marker blocks
+- **WHEN** `preventGeneratedFileEdits: true` is configured
+- **AND** Claude attempts to edit a file containing a generation marker
+- **THEN** the system SHALL block the operation with the default message format
+- **AND** the message SHALL include the file path and detected marker
+- **AND** no customization of this message SHALL be available

--- a/spectr/changes/remove-generated-file-message/tasks.md
+++ b/spectr/changes/remove-generated-file-message/tasks.md
@@ -1,0 +1,30 @@
+## 1. Code Changes
+
+- [ ] 1.1 Remove `generated_file_message` field from `PreToolUseConfig` struct in `src/config.rs`
+- [ ] 1.2 Remove doc comments and serde attributes for the field in `src/config.rs`
+- [ ] 1.3 Remove field from `Default` implementation in `src/config.rs`
+- [ ] 1.4 Remove field from help text listing in `src/config.rs`
+- [ ] 1.5 Remove field from field name list in `src/config.rs`
+
+## 2. Hook Logic Update
+
+- [ ] 2.1 Update `check_generated_file_edits` in `src/hooks.rs` to remove custom message handling
+- [ ] 2.2 Always use the default hardcoded message format
+
+## 3. Configuration Files
+
+- [ ] 3.1 Remove `generatedFileMessage` from `src/default-config.yaml`
+- [ ] 3.2 Remove `generatedFileMessage` from `conclaude-schema.json`
+- [ ] 3.3 Remove `generatedFileMessage` from `.conclaude.yaml` example file
+
+## 4. Documentation
+
+- [ ] 4.1 Remove `generatedFileMessage` section from `docs/src/content/docs/reference/config/pre-tool-use.md`
+- [ ] 4.2 Remove from table in `docs/src/content/docs/reference/config/configuration.md`
+
+## 5. Validation
+
+- [ ] 5.1 Run `cargo build` to ensure code compiles
+- [ ] 5.2 Run `cargo test` to ensure tests pass
+- [ ] 5.3 Run `cargo clippy` to check for lint issues
+- [ ] 5.4 Verify schema regeneration if needed


### PR DESCRIPTION
## Summary

Proposal for review: `remove-generated-file-message`

**Location**: `spectr/changes/remove-generated-file-message/`

## Files

- `proposal.md` - Change overview
- `tasks.md` - Implementation checklist
- `specs/` - Delta specifications

## Review Checklist

- [ ] Proposal addresses the stated problem
- [ ] Delta specs are properly formatted
- [ ] Tasks are clear and actionable

---
*Generated by `spectr pr proposal`*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Breaking Changes**
  * Removed `generatedFileMessage` configuration option. Generated file edit blocks now use a default message format instead of custom messages.

* **Configuration**
  * Configuration validation will now fail if `generatedFileMessage` is present in settings.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->