### PR TITLE
spectr(proposal): add-init-hook-timeout

### DIFF
--- a/spectr/changes/add-init-hook-timeout/proposal.md
+++ b/spectr/changes/add-init-hook-timeout/proposal.md
@@ -1,0 +1,21 @@
+# Change: Add timeout field to generated Claude Code hooks
+
+## Why
+
+The `conclaude init` command generates Claude Code hook configurations in `.claude/settings.json`, but these hooks do not include a `timeout` field. According to the Claude Code hooks reference, hooks support an optional `timeout` field (in seconds) that specifies how long a hook should run before being cancelled. Without a timeout, long-running hooks could potentially hang indefinitely, blocking Claude Code sessions.
+
+Setting a default timeout of 10 minutes (600 seconds) provides:
+- Protection against runaway hook processes
+- Predictable behavior for users
+- Alignment with Claude Code's documented hook configuration options
+
+## What Changes
+
+- **Modify `handle_init` function**: Update the `ClaudeHookConfig` struct and hook generation logic to include a `timeout: 600` field (10 minutes) for all generated hooks
+- **Update `ClaudeHookConfig` struct**: Add optional `timeout` field to match Claude Code's hook schema
+
+## Impact
+
+- Affected specs: initialization (new spec)
+- Affected code: `src/main.rs` (handle_init function, ClaudeHookConfig struct)
+- User impact: Newly initialized projects will have hooks with 10-minute timeouts; existing projects are unaffected unless they re-run `conclaude init --force`

--- a/spectr/changes/add-init-hook-timeout/specs/initialization/spec.md
+++ b/spectr/changes/add-init-hook-timeout/specs/initialization/spec.md
@@ -1,0 +1,32 @@
+## ADDED Requirements
+
+### Requirement: Generated Hooks Include Timeout Configuration
+
+The `conclaude init` command SHALL generate Claude Code hook configurations that include a timeout field to prevent indefinite hook execution.
+
+#### Scenario: Default timeout for generated hooks
+
+- **WHEN** a user runs `conclaude init` to initialize a project
+- **THEN** the generated `.claude/settings.json` SHALL include hook configurations with a `timeout` field
+- **AND** the timeout value SHALL be 600 seconds (10 minutes)
+- **AND** all hook types (PreToolUse, PostToolUse, Stop, etc.) SHALL have the same timeout value
+
+#### Scenario: Settings.json hook structure with timeout
+
+- **WHEN** the `.claude/settings.json` file is generated or updated
+- **THEN** each hook configuration SHALL follow the Claude Code hooks schema:
+  ```json
+  {
+    "type": "command",
+    "command": "conclaude Hooks <HookType>",
+    "timeout": 600
+  }
+  ```
+- **AND** the timeout field SHALL be a positive integer representing seconds
+
+#### Scenario: Existing settings preserved with timeout added
+
+- **WHEN** a user runs `conclaude init` on a project with existing `.claude/settings.json`
+- **AND** the `--force` flag is not specified
+- **THEN** existing hooks SHALL be updated to include the timeout field
+- **AND** other existing settings (permissions, includeCoAuthoredBy, etc.) SHALL be preserved

--- a/spectr/changes/add-init-hook-timeout/tasks.md
+++ b/spectr/changes/add-init-hook-timeout/tasks.md
@@ -1,0 +1,11 @@
+## 1. Implementation
+
+- [ ] 1.1 Add optional `timeout` field to `ClaudeHookConfig` struct in `src/main.rs`
+- [ ] 1.2 Update hook generation in `handle_init` to include `timeout: 600` for all hooks
+- [ ] 1.3 Test `conclaude init` generates settings.json with timeout field
+
+## 2. Validation
+
+- [ ] 2.1 Run `cargo build` to verify compilation
+- [ ] 2.2 Run `cargo test` to verify existing tests pass
+- [ ] 2.3 Manually test `conclaude init` in a temp directory and verify generated settings.json includes timeout


### PR DESCRIPTION
## Summary

Proposal for review: `add-init-hook-timeout`

**Location**: `spectr/changes/add-init-hook-timeout/`

## Files

- `proposal.md` - Change overview
- `tasks.md` - Implementation checklist
- `specs/` - Delta specifications

## Review Checklist

- [ ] Proposal addresses the stated problem
- [ ] Delta specs are properly formatted
- [ ] Tasks are clear and actionable

---
*Generated by `spectr pr proposal`*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Generated hook configurations now include a timeout field.
  * Default timeout is 600 seconds for all newly initialized hooks.
  * Existing project configurations remain unchanged unless reinitialized.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->