### PR TITLE
spectr(proposal): add-show-command-config

### DIFF
--- a/spectr/changes/add-show-command-config/proposal.md
+++ b/spectr/changes/add-show-command-config/proposal.md
@@ -1,0 +1,22 @@
+# Change: Add showCommand Configuration Option
+
+## Why
+
+When running stop hook commands, conclaude currently always prints "Executing command X/Y: <command>" to stdout. Some users want to suppress this output for cleaner logs when the command itself is not informative (e.g., `npm test` is self-explanatory) or when running many commands where the output becomes noisy.
+
+## What Changes
+
+- Add `showCommand` boolean field to `StopCommand` struct (default: `true`)
+- Add `showCommand` boolean field to `SubagentStopCommand` struct (default: `true`)
+- When `showCommand: false`, suppress the "Executing command X/Y: <command>" output line
+- When `showCommand: true` (default), preserve current behavior
+- Update JSON schema to include the new field
+
+## Impact
+
+- Affected specs: `execution`
+- Affected code:
+  - `src/config.rs` - Add `showCommand` field to `StopCommand` and `SubagentStopCommand` structs
+  - `src/hooks.rs` - Conditionally print command execution line based on `showCommand` value
+  - `conclaude-schema.json` - Auto-generated, will include new field
+- Backward compatible: Existing configs work unchanged (default `true` preserves current behavior)

--- a/spectr/changes/add-show-command-config/specs/execution/spec.md
+++ b/spectr/changes/add-show-command-config/specs/execution/spec.md
@@ -1,0 +1,47 @@
+## ADDED Requirements
+
+### Requirement: Command Execution Display Configuration
+
+The system SHALL provide an optional `showCommand` field for individual stop commands in the configuration to control whether the command being executed is displayed in stdout.
+
+#### Scenario: Command with showCommand explicitly set to true
+
+- **WHEN** a stop command includes `showCommand` field set to `true`
+- **THEN** the system SHALL print "Executing command X/Y: <command>" to stdout before execution
+- **AND** this matches the current default behavior
+
+#### Scenario: Command with showCommand set to false
+
+- **WHEN** a stop command includes `showCommand` field set to `false`
+- **THEN** the system SHALL NOT print "Executing command X/Y: <command>" to stdout
+- **AND** the command SHALL still execute normally
+- **AND** command output (stdout/stderr) SHALL still be controlled by `showStdout`/`showStderr` flags independently
+
+#### Scenario: Command without showCommand configured
+
+- **WHEN** a stop command does not include a `showCommand` field
+- **THEN** the system SHALL default to `true`
+- **AND** the system SHALL print "Executing command X/Y: <command>" to stdout
+- **AND** existing behavior SHALL be preserved for backward compatibility
+
+#### Scenario: showCommand with subagent stop commands
+
+- **WHEN** a subagent stop command includes `showCommand` field
+- **THEN** the same display control behavior SHALL apply as with regular stop commands
+- **AND** the subagent stop command execution line SHALL be suppressed when `showCommand` is `false`
+
+### Requirement: showCommand Configuration Validation
+
+The system SHALL validate `showCommand` values in the configuration to ensure they are properly formatted.
+
+#### Scenario: Valid showCommand value
+
+- **WHEN** `showCommand` field contains a boolean value (`true` or `false`)
+- **THEN** the configuration SHALL be accepted
+- **AND** the display setting SHALL be applied during command execution
+
+#### Scenario: Invalid showCommand value
+
+- **WHEN** `showCommand` field contains a non-boolean value
+- **THEN** the configuration loading SHALL fail with a validation error
+- **AND** the error message SHALL indicate the `showCommand` value format issue

--- a/spectr/changes/add-show-command-config/tasks.md
+++ b/spectr/changes/add-show-command-config/tasks.md
@@ -1,0 +1,28 @@
+## 1. Implementation
+
+- [ ] 1.1 Add `show_command` field to `StopCommand` struct in `src/config.rs` with `#[serde(default = "default_true", rename = "showCommand")]`
+- [ ] 1.2 Add `show_command` field to `SubagentStopCommand` struct in `src/config.rs` with same attributes
+- [ ] 1.3 Add `default_true` helper function returning `Some(true)` if not already present
+- [ ] 1.4 Update `StopCommandConfig` struct in `src/hooks.rs` to include `show_command: bool` field
+- [ ] 1.5 Update `SubagentStopCommandConfig` struct in `src/hooks.rs` to include `show_command: bool` field
+- [ ] 1.6 Update `build_stop_commands` function to propagate `show_command` value (default to `true`)
+- [ ] 1.7 Update `build_subagent_stop_commands` function to propagate `show_command` value (default to `true`)
+- [ ] 1.8 Conditionally print "Executing command X/Y: <command>" based on `show_command` in `execute_stop_commands`
+- [ ] 1.9 Conditionally print command execution line in `execute_subagent_stop_commands`
+
+## 2. Schema Update
+
+- [ ] 2.1 Regenerate `conclaude-schema.json` with `cargo run -- generate-schema`
+
+## 3. Testing
+
+- [ ] 3.1 Add unit test: config parsing with `showCommand: true` explicit
+- [ ] 3.2 Add unit test: config parsing with `showCommand: false`
+- [ ] 3.3 Add unit test: config parsing without `showCommand` (verify default `true`)
+- [ ] 3.4 Add integration test: verify command line is printed when `showCommand: true`
+- [ ] 3.5 Add integration test: verify command line is suppressed when `showCommand: false`
+
+## 4. Documentation
+
+- [ ] 4.1 Update `.conclaude.yaml` comments with `showCommand` option
+- [ ] 4.2 Update README.md command configuration section


### PR DESCRIPTION
## Summary

Proposal for review: `add-show-command-config`

**Location**: `spectr/changes/add-show-command-config/`

## Files

- `proposal.md` - Change overview
- `tasks.md` - Implementation checklist
- `specs/` - Delta specifications

## Review Checklist

- [ ] Proposal addresses the stated problem
- [ ] Delta specs are properly formatted
- [ ] Tasks are clear and actionable

---
*Generated by `spectr pr proposal`*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `showCommand` configuration option for stop commands to control whether execution details are displayed. When enabled (default), shows command execution information; when disabled, suppresses the output. Preserves existing behavior by default.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->