### PR TITLE
fix: apply max_output_lines to stop command diagnostic output

### DIFF
--- a/src/hooks.rs
+++ b/src/hooks.rs
@@ -1045,32 +1045,42 @@ async fn execute_stop_commands(
             };
 
             // Only include Stdout section if showStdout is true
-            if cmd_config.show_stdout {
-                let stdout_display = if stdout.trim().is_empty() {
-                    "    (no stdout)".to_string()
+            if cmd_config.show_stdout && !stdout.trim().is_empty() {
+                let stdout_content = if let Some(max_lines) = cmd_config.max_output_lines {
+                    let (truncated, is_truncated, omitted) = truncate_output(&stdout, max_lines);
+                    if is_truncated {
+                        format!("{}\n... ({} lines omitted)", truncated, omitted)
+                    } else {
+                        truncated
+                    }
                 } else {
-                    stdout
-                        .trim()
-                        .lines()
-                        .map(|line| format!("    {}", line))
-                        .collect::<Vec<_>>()
-                        .join("\n")
+                    stdout.trim().to_string()
                 };
+                let stdout_display = stdout_content
+                    .lines()
+                    .map(|line| format!("    {}", line))
+                    .collect::<Vec<_>>()
+                    .join("\n");
                 diagnostic.push_str(&format!("\n  Stdout:\n{}", stdout_display));
             }
 
             // Only include Stderr section if showStderr is true
-            if cmd_config.show_stderr {
-                let stderr_display = if stderr.trim().is_empty() {
-                    "    (no stderr)".to_string()
+            if cmd_config.show_stderr && !stderr.trim().is_empty() {
+                let stderr_content = if let Some(max_lines) = cmd_config.max_output_lines {
+                    let (truncated, is_truncated, omitted) = truncate_output(&stderr, max_lines);
+                    if is_truncated {
+                        format!("{}\n... ({} lines omitted)", truncated, omitted)
+                    } else {
+                        truncated
+                    }
                 } else {
-                    stderr
-                        .trim()
-                        .lines()
-                        .map(|line| format!("    {}", line))
-                        .collect::<Vec<_>>()
-                        .join("\n")
+                    stderr.trim().to_string()
                 };
+                let stderr_display = stderr_content
+                    .lines()
+                    .map(|line| format!("    {}", line))
+                    .collect::<Vec<_>>()
+                    .join("\n");
                 diagnostic.push_str(&format!("\n  Stderr:\n{}", stderr_display));
             }
 


### PR DESCRIPTION
## Summary

- Fixed `maxOutputLines` config setting not being applied to diagnostic output in `execute_stop_commands()`
- When a stop command failed, stdout/stderr in the diagnostic was showing ALL lines regardless of the configured limit
- Applied `truncate_output()` before formatting the diagnostic, matching the working pattern from `execute_subagent_stop_commands()`

## Test plan

- [x] Verified `cargo test max_output` passes (5 tests)
- [x] Verified `cargo test truncate` passes (5 tests)
- [x] Verified `cargo test stop` passes (32 tests)
- [x] Code follows existing pattern in `execute_subagent_stop_commands()`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved stop command output formatting by removing empty stdout/stderr placeholders. Output sections now appear only when containing data, with optional truncation and "lines omitted" indicators for long outputs.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->