### PR TITLE
spectr(proposal): add-per-command-notifications

### DIFF
--- a/spectr/changes/add-per-command-notifications/proposal.md
+++ b/spectr/changes/add-per-command-notifications/proposal.md
@@ -1,0 +1,95 @@
+# Proposal: Add Per-Command Notifications
+
+## Problem Statement
+
+Currently, conclaude sends one notification per hook execution regardless of how many commands are configured. For example, if a `Stop` hook has 3 commands (`npm test`, `npm run build`, `git status`), users receive only a single notification when all commands complete or when one fails.
+
+This creates two issues:
+1. **Lack of real-time feedback**: Users don't know which specific command is running or has completed
+2. **Poor failure context**: When a command fails, the notification doesn't indicate which command in the sequence caused the failure
+
+Users who configure multiple commands in their hooks would benefit from per-command notifications to monitor progress and quickly identify failures.
+
+## Proposed Solution
+
+Add an optional `notifyPerCommand` boolean field to command configurations that enables sending individual notifications for each command execution. This provides granular feedback without changing the default behavior.
+
+### User-facing behavior
+
+When `notifyPerCommand: true` is configured on a command:
+- A notification is sent when the command **starts** execution (optional, controlled by notification config)
+- A notification is sent when the command **completes** (success or failure)
+- The notification includes the command name (if `showCommand: true`) or a generic message
+- All existing notification filters (`hooks`, `showErrors`, `showSuccess`) continue to apply
+
+### Configuration example
+
+```yaml
+stop:
+  commands:
+    - run: npm test
+      notifyPerCommand: true  # New field
+      showCommand: true
+    - run: npm run build
+      notifyPerCommand: true
+    - run: git status
+      # notifyPerCommand defaults to false (existing behavior)
+
+notifications:
+  enabled: true
+  hooks: ["Stop"]
+  showErrors: true
+  showSuccess: true
+```
+
+With this configuration:
+- Hook-level notification: "Stop hook started" (existing)
+- Command 1 notification: "Running: npm test" (new)
+- Command 1 notification: "Command completed: npm test" (new)
+- Command 2 notification: "Running: npm run build" (new)
+- Command 2 notification: "Command completed: npm run build" (new)
+- Command 3: No per-command notifications (notifyPerCommand: false)
+- Hook-level notification: "Stop hook completed" (existing)
+
+## Impact Analysis
+
+### Breaking Changes
+None. This is a purely additive feature with default behavior unchanged.
+
+### Configuration Changes
+- Add optional `notifyPerCommand: bool` field to `StopCommand` struct
+- Add optional `notifyPerCommand: bool` field to `SubagentStopCommand` struct
+- Update JSON schema to include new field
+
+### Performance Impact
+Minimal. Notifications are non-blocking and failures are gracefully handled.
+
+### User Experience
+- **Improved**: Users who want granular feedback can opt-in
+- **Unchanged**: Users who don't configure the field see existing behavior
+
+## Alternatives Considered
+
+### Alternative 1: Always send per-command notifications
+**Rejected**: Would spam users who have many commands configured and don't need that level of detail.
+
+### Alternative 2: Add a global `notifyPerCommand` setting
+**Rejected**: Less flexible than per-command control. Some commands may warrant notifications while others don't.
+
+### Alternative 3: Only send start OR complete notifications
+**Rejected**: Both are valuable - start notifications show progress, complete notifications confirm success/failure.
+
+## Success Criteria
+
+1. Users can enable per-command notifications on individual commands
+2. Notifications include command context (name if shown, generic message otherwise)
+3. Per-command notifications respect all existing notification filters
+4. Default behavior (no per-command notifications) is preserved
+5. Validation passes for both valid and invalid configurations
+
+## Out of Scope
+
+- Command progress bars or percentage indicators
+- Notification grouping or batching
+- Custom notification templates per command
+- Start notifications controlled separately from completion notifications

--- a/spectr/changes/add-per-command-notifications/specs/execution/spec.md
+++ b/spectr/changes/add-per-command-notifications/specs/execution/spec.md
@@ -1,0 +1,77 @@
+# execution Specification Delta
+
+## ADDED Requirements
+
+### Requirement: Per-Command Notification Integration
+
+The system SHALL integrate per-command notifications into the command execution pipeline for both stop and subagent stop commands.
+
+#### Scenario: Stop command execution with per-command notifications
+
+- **WHEN** a stop command has `notifyPerCommand: true`
+- **THEN** the system SHALL call `send_notification()` before command execution
+- **AND** the notification SHALL use the hook name "Stop" with context indicating command start
+- **AND** the system SHALL call `send_notification()` after command execution completes
+- **AND** the notification status SHALL be "success" or "failure" based on exit code
+
+#### Scenario: Subagent stop command execution with per-command notifications
+
+- **WHEN** a subagent stop command has `notifyPerCommand: true`
+- **THEN** the system SHALL call `send_notification()` before command execution
+- **AND** the notification SHALL use the hook name "SubagentStop" with context indicating command start
+- **AND** the system SHALL call `send_notification()` after command execution completes
+- **AND** the notification status SHALL be "success" or "failure" based on exit code
+
+#### Scenario: Command execution without per-command notifications
+
+- **WHEN** a command has `notifyPerCommand: false` or omits the field
+- **THEN** the system SHALL NOT call `send_notification()` for command start
+- **AND** the system SHALL NOT call `send_notification()` for command completion
+- **AND** only hook-level notifications SHALL be sent
+
+### Requirement: Per-Command Notification Message Formatting
+
+The system SHALL format per-command notification messages based on command configuration.
+
+#### Scenario: Notification message with showCommand enabled
+
+- **WHEN** generating a per-command notification for a command with `showCommand: true`
+- **THEN** the start notification context SHALL include the command string (e.g., "Running: npm test")
+- **AND** the completion notification context SHALL include the command string and status (e.g., "Completed: npm test")
+
+#### Scenario: Notification message with showCommand disabled
+
+- **WHEN** generating a per-command notification for a command with `showCommand: false`
+- **THEN** the start notification context SHALL use a generic format (e.g., "Running command 2/5")
+- **AND** the completion notification context SHALL use a generic format (e.g., "Command 2/5 completed")
+- **AND** the command string SHALL NOT appear in the notification
+
+#### Scenario: Notification message includes command index
+
+- **WHEN** generating a per-command notification for any command
+- **THEN** the notification context MAY include the command index and total count
+- **AND** the format SHALL be "X/Y" where X is the current command number and Y is total commands
+
+### Requirement: Per-Command Notification Configuration Propagation
+
+The system SHALL propagate the `notifyPerCommand` configuration flag through the command execution pipeline.
+
+#### Scenario: notifyPerCommand flag in StopCommandConfig
+
+- **WHEN** collecting stop commands from configuration
+- **THEN** the `StopCommandConfig` struct SHALL include a `notify_per_command` boolean field
+- **AND** the field SHALL be populated from the command configuration's `notifyPerCommand` value
+- **AND** the field SHALL default to `false` when not specified
+
+#### Scenario: notifyPerCommand flag in SubagentStopCommandConfig
+
+- **WHEN** collecting subagent stop commands from configuration
+- **THEN** the `SubagentStopCommandConfig` struct SHALL include a `notify_per_command` boolean field
+- **AND** the field SHALL be populated from the command configuration's `notifyPerCommand` value
+- **AND** the field SHALL default to `false` when not specified
+
+#### Scenario: notifyPerCommand flag during execution
+
+- **WHEN** executing commands in `execute_stop_commands()` or `execute_subagent_stop_commands()`
+- **THEN** the execution loop SHALL check the `notify_per_command` flag for each command
+- **AND** notifications SHALL be sent conditionally based on this flag

--- a/spectr/changes/add-per-command-notifications/specs/notifications/spec.md
+++ b/spectr/changes/add-per-command-notifications/specs/notifications/spec.md
@@ -1,0 +1,117 @@
+# notifications Specification Delta
+
+## ADDED Requirements
+
+### Requirement: Per-Command Notification Configuration
+
+The system SHALL provide an optional `notifyPerCommand` field for individual stop and subagent stop commands to enable notifications for each command execution.
+
+#### Scenario: Command with notifyPerCommand enabled
+
+- **WHEN** a stop command includes `notifyPerCommand: true`
+- **AND** notifications are enabled for the Stop hook
+- **THEN** the system SHALL send a notification when the command starts execution
+- **AND** the system SHALL send a notification when the command completes (success or failure)
+
+#### Scenario: Command with notifyPerCommand disabled
+
+- **WHEN** a stop command includes `notifyPerCommand: false` or omits the field
+- **THEN** the system SHALL NOT send per-command notifications
+- **AND** only hook-level notifications SHALL be sent
+
+#### Scenario: Per-command notifications respect hook filters
+
+- **WHEN** a command has `notifyPerCommand: true`
+- **AND** the Stop hook is not in the `notifications.hooks` array
+- **THEN** no per-command notifications SHALL be sent
+- **AND** the hook filter takes precedence over per-command settings
+
+### Requirement: Per-Command Notification Content
+
+The system SHALL include command-specific context in per-command notifications when enabled.
+
+#### Scenario: Per-command notification with showCommand enabled
+
+- **WHEN** a command has `notifyPerCommand: true` and `showCommand: true`
+- **THEN** the start notification SHALL include the command being executed (e.g., "Running: npm test")
+- **AND** the completion notification SHALL include the command name (e.g., "Completed: npm test" or "Failed: npm test")
+
+#### Scenario: Per-command notification with showCommand disabled
+
+- **WHEN** a command has `notifyPerCommand: true` and `showCommand: false`
+- **THEN** the start notification SHALL use a generic message (e.g., "Running command 1/3")
+- **AND** the completion notification SHALL use a generic message (e.g., "Command 1/3 completed")
+
+#### Scenario: Per-command failure notification includes context
+
+- **WHEN** a command with `notifyPerCommand: true` fails
+- **AND** `notifications.showErrors` is true
+- **THEN** the notification SHALL indicate failure status
+- **AND** the notification MAY include the exit code or error summary
+
+### Requirement: Per-Command Notification Filtering
+
+The system SHALL apply all existing notification filters to per-command notifications.
+
+#### Scenario: Per-command notifications respect showSuccess filter
+
+- **WHEN** a command with `notifyPerCommand: true` completes successfully
+- **AND** `notifications.showSuccess` is false
+- **THEN** no success notification SHALL be sent for that command
+- **AND** only failure notifications (if any) SHALL be sent
+
+#### Scenario: Per-command notifications respect showErrors filter
+
+- **WHEN** a command with `notifyPerCommand: true` fails
+- **AND** `notifications.showErrors` is false
+- **THEN** no failure notification SHALL be sent for that command
+- **AND** only success notifications (if any) SHALL be sent
+
+#### Scenario: Per-command notifications respect showSystemEvents filter
+
+- **WHEN** a command with `notifyPerCommand: true` starts or completes
+- **THEN** `notifications.showSystemEvents` SHALL NOT affect per-command notifications
+- **AND** per-command notifications SHALL be controlled by `showSuccess` and `showErrors` flags only
+
+### Requirement: Per-Command Notification Validation
+
+The system SHALL validate `notifyPerCommand` values in configuration to ensure proper formatting.
+
+#### Scenario: Valid notifyPerCommand value
+
+- **WHEN** `notifyPerCommand` field contains a boolean value (`true` or `false`)
+- **THEN** the configuration SHALL be accepted
+- **AND** the notification behavior SHALL be applied during command execution
+
+#### Scenario: Invalid notifyPerCommand value
+
+- **WHEN** `notifyPerCommand` field contains a non-boolean value
+- **THEN** the configuration loading SHALL fail with a validation error
+- **AND** the error message SHALL indicate the `notifyPerCommand` value format issue
+
+#### Scenario: Missing notifyPerCommand field
+
+- **WHEN** a command configuration omits the `notifyPerCommand` field
+- **THEN** the system SHALL default to `false`
+- **AND** no per-command notifications SHALL be sent
+
+## MODIFIED Requirements
+
+### Requirement: Notification Timing
+
+The system SHALL send notifications at appropriate times during hook and command execution.
+
+#### Scenario: Hook-level and per-command notifications coexist
+
+- **WHEN** a hook executes with some commands having `notifyPerCommand: true`
+- **THEN** the system SHALL send hook start notification (if configured)
+- **AND** the system SHALL send per-command notifications for enabled commands
+- **AND** the system SHALL send hook completion notification (if configured)
+- **AND** notifications SHALL be sent in execution order without batching
+
+#### Scenario: Multiple commands with notifyPerCommand enabled
+
+- **WHEN** multiple commands in a hook have `notifyPerCommand: true`
+- **THEN** each command SHALL generate its own start and completion notifications
+- **AND** notifications SHALL be sent in the order commands execute
+- **AND** the system SHALL NOT batch or suppress per-command notifications

--- a/spectr/changes/add-per-command-notifications/tasks.md
+++ b/spectr/changes/add-per-command-notifications/tasks.md
@@ -1,0 +1,49 @@
+# Implementation Tasks: Add Per-Command Notifications
+
+## Configuration Schema (5 tasks)
+
+- [ ] Add `notifyPerCommand` optional boolean field to `StopCommand` struct in `src/config.rs`
+- [ ] Add `notifyPerCommand` optional boolean field to `SubagentStopCommand` struct in `src/config.rs`
+- [ ] Update JSON schema (`conclaude-schema.json`) to include `notifyPerCommand` field for stop commands
+- [ ] Update JSON schema to include `notifyPerCommand` field for subagent stop commands
+- [ ] Add configuration validation test for valid and invalid `notifyPerCommand` values
+
+## Notification Logic (4 tasks)
+
+- [ ] Add per-command notification support to `execute_stop_commands()` in `src/hooks.rs`
+- [ ] Add per-command notification support to `execute_subagent_stop_commands()` in `src/hooks.rs`
+- [ ] Ensure per-command notifications respect `showCommand` flag (show command name vs generic message)
+- [ ] Ensure per-command notifications respect existing notification filters (`hooks`, `showErrors`, `showSuccess`)
+
+## Command Execution (3 tasks)
+
+- [ ] Pass `notifyPerCommand` flag from `StopCommandConfig` through execution pipeline
+- [ ] Pass `notifyPerCommand` flag from `SubagentStopCommandConfig` through execution pipeline
+- [ ] Send start notification before command execution (if `notifyPerCommand: true` and notifications enabled)
+- [ ] Send completion notification after command execution (if `notifyPerCommand: true` and notifications enabled)
+
+## Testing (5 tasks)
+
+- [ ] Add unit test for per-command notification with `showCommand: true` (shows command name)
+- [ ] Add unit test for per-command notification with `showCommand: false` (generic message)
+- [ ] Add unit test verifying notifications respect `showErrors` and `showSuccess` filters
+- [ ] Add integration test for stop hook with mixed `notifyPerCommand` settings
+- [ ] Add integration test for subagent stop hook with `notifyPerCommand` enabled
+
+## Documentation (3 tasks)
+
+- [ ] Update configuration documentation for `Stop` commands to include `notifyPerCommand`
+- [ ] Update configuration documentation for `SubagentStop` commands to include `notifyPerCommand`
+- [ ] Add example configuration showing per-command notifications in use
+
+## Total: 20 tasks
+
+### Parallelizable Work
+- Configuration schema tasks (1-5) can be done in parallel with notification logic tasks (6-9)
+- Testing tasks (14-18) can be done in parallel after implementation is complete
+- Documentation tasks (19-21) can be done in parallel with testing
+
+### Dependencies
+- Command execution tasks (10-13) depend on configuration schema (1-5) and notification logic (6-9)
+- Testing tasks (14-18) depend on all implementation tasks (1-13)
+- Documentation tasks (19-21) have no strict dependencies


### PR DESCRIPTION
## Summary

Proposal for review: `add-per-command-notifications`

**Location**: `spectr/changes/add-per-command-notifications/`

## Files

- `proposal.md` - Change overview
- `tasks.md` - Implementation checklist
- `specs/` - Delta specifications

## Review Checklist

- [ ] Proposal addresses the stated problem
- [ ] Delta specs are properly formatted
- [ ] Tasks are clear and actionable

---
*Generated by `spectr pr proposal`*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced per-command notifications feature with a configurable `notifyPerCommand` option, enabling individual notifications for each command within a hook, including optional start and completion alerts with command context display. Fully opt-in with backward compatibility.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->