### PR TITLE
spectr(proposal): add-pretooluse-updatedinput-ask-support

### DIFF
--- a/spectr/changes/add-pretooluse-updatedinput-ask-support/proposal.md
+++ b/spectr/changes/add-pretooluse-updatedinput-ask-support/proposal.md
@@ -1,0 +1,71 @@
+# Proposal: Add updatedInput Support for PreToolUse Hooks with Ask Decision
+
+## Why
+
+Claude Code recently added support for `updatedInput` when returning an `ask` permission decision in PreToolUse hooks. This enables hooks to act as middleware that can modify tool inputs while still requesting user consent before execution. Conclaude must support this pattern to maintain compatibility with the Claude Code hook protocol.
+
+## Problem
+
+Currently, conclaude's `HookResult` struct only supports:
+- `message`: Optional custom message
+- `blocked`: Boolean to allow/block the operation
+- `system_prompt`: Optional context injection
+
+Claude Code now supports returning both `updatedInput` (modified tool parameters) and `permissionDecision: "ask"` together in `hookSpecificOutput`. This allows hooks to:
+1. Sanitize or transform tool inputs
+2. Still require user approval before the modified operation proceeds
+
+Without this support, conclaude cannot act as middleware for PreToolUse hooks while preserving user consent.
+
+## Context
+
+Claude Code's PreToolUse hooks now support three permission decisions:
+- **`allow`**: Bypasses permission system, proceeds with (optionally modified) input
+- **`deny`**: Blocks the tool call with a reason
+- **`ask`**: Prompts user to confirm, showing `permissionDecisionReason` (NEW: now supports `updatedInput`)
+
+The fix in Claude Code enables `updatedInput` to work with `ask`, allowing hooks to function as middleware while maintaining the user consent flow.
+
+## Proposed Solution
+
+Extend conclaude's `HookResult` struct to include:
+1. **`updated_input`**: Optional `HashMap<String, serde_json::Value>` for modified tool parameters
+2. **`decision`**: Optional string for explicit permission decisions (`"allow"`, `"deny"`, `"ask"`)
+
+This allows hooks to return:
+```json
+{
+  "decision": "ask",
+  "message": "Modified command requires approval",
+  "updated_input": {
+    "command": "sanitized-command"
+  }
+}
+```
+
+## Impact
+
+- **Affected specs**: preToolUse, hooks-system
+- **Affected code**:
+  - `src/types.rs` - Extend HookResult struct
+  - `src/hooks.rs` - Handle updated_input in PreToolUse response
+- **Configuration**: No config schema changes needed
+- **Breaking changes**: None - new optional fields maintain backward compatibility
+
+## Dependencies
+
+None - this is a self-contained extension to the hook response protocol.
+
+## Alternatives Considered
+
+1. **Separate response type for PreToolUse** - Rejected: adds unnecessary complexity when optional fields suffice
+2. **Only support updatedInput with allow** - Rejected: doesn't align with Claude Code's capabilities
+3. **Wrap in hookSpecificOutput structure** - Considered: could add for full Claude Code alignment, but flat structure is simpler for now
+
+## Success Criteria
+
+- [ ] `updated_input` field added to HookResult as optional HashMap
+- [ ] `decision` field added to HookResult as optional String
+- [ ] PreToolUse handler respects `decision: "ask"` with `updated_input`
+- [ ] Tests verify serialization/deserialization of new fields
+- [ ] `spectr validate` passes

--- a/spectr/changes/add-pretooluse-updatedinput-ask-support/specs/preToolUse/spec.md
+++ b/spectr/changes/add-pretooluse-updatedinput-ask-support/specs/preToolUse/spec.md
@@ -1,0 +1,108 @@
+# PreToolUse Specification Delta
+
+## ADDED Requirements
+
+### Requirement: Updated Input with Ask Permission Decision
+
+The system SHALL support returning `updatedInput` alongside an `ask` permission decision in PreToolUse hook responses, enabling hooks to act as middleware that modifies tool inputs while still requesting user consent.
+
+#### Scenario: Ask decision with updated input
+- **WHEN** a PreToolUse hook returns `decision: "ask"` with `updated_input` containing modified parameters
+- **THEN** the system SHALL serialize both the decision and updated input in the response
+- **AND** the user SHALL be prompted to approve the modified operation
+- **AND** if approved, the tool SHALL execute with the modified input parameters
+
+#### Scenario: Ask decision with reason and updated input
+- **GIVEN** a PreToolUse hook that sanitizes bash commands
+- **WHEN** the hook returns:
+  ```json
+  {
+    "decision": "ask",
+    "message": "Command modified for safety",
+    "updated_input": {
+      "command": "sanitized-command"
+    }
+  }
+  ```
+- **THEN** the user SHALL see the reason message
+- **AND** if the user approves, the sanitized command SHALL be executed
+- **AND** if the user denies, the operation SHALL be blocked
+
+#### Scenario: Ask decision without updated input (backward compatible)
+- **WHEN** a PreToolUse hook returns `decision: "ask"` without `updated_input`
+- **THEN** the system SHALL prompt for user approval with the original tool input
+- **AND** behavior SHALL be identical to the legacy permission flow
+
+#### Scenario: Updated input partial replacement
+- **GIVEN** a tool input with fields: `{ "command": "rm -rf /", "timeout": 30 }`
+- **WHEN** a hook returns `updated_input: { "command": "echo hello" }`
+- **THEN** only the `command` field SHALL be replaced
+- **AND** the `timeout` field SHALL remain unchanged at 30
+- **AND** the final input SHALL be `{ "command": "echo hello", "timeout": 30 }`
+
+### Requirement: Permission Decision Field
+
+The system SHALL support an explicit `decision` field in PreToolUse hook responses with values: "allow", "deny", or "ask".
+
+#### Scenario: Decision field allow
+- **WHEN** a PreToolUse hook returns `decision: "allow"`
+- **THEN** the tool execution SHALL proceed without user prompt
+- **AND** any `updated_input` SHALL be applied to the tool parameters
+- **AND** behavior SHALL be equivalent to returning `blocked: false`
+
+#### Scenario: Decision field deny
+- **WHEN** a PreToolUse hook returns `decision: "deny"`
+- **THEN** the tool execution SHALL be blocked
+- **AND** the `message` field SHALL be shown to Claude as the reason
+- **AND** behavior SHALL be equivalent to returning `blocked: true`
+
+#### Scenario: Decision field ask
+- **WHEN** a PreToolUse hook returns `decision: "ask"`
+- **THEN** the user SHALL be prompted to approve or deny the operation
+- **AND** the `message` field SHALL be shown to the user (not Claude)
+- **AND** any `updated_input` SHALL be applied if the user approves
+
+#### Scenario: Decision field takes precedence over blocked
+- **WHEN** a PreToolUse hook returns both `decision: "allow"` and `blocked: true`
+- **THEN** the `decision` field SHALL take precedence
+- **AND** the tool SHALL be allowed to execute
+- **AND** a warning MAY be logged about conflicting fields
+
+#### Scenario: Missing decision field uses blocked field
+- **WHEN** a PreToolUse hook returns without a `decision` field
+- **THEN** the system SHALL use the `blocked` field to determine behavior
+- **AND** `blocked: true` SHALL block the operation
+- **AND** `blocked: false` SHALL allow the operation
+- **AND** backward compatibility SHALL be maintained
+
+### Requirement: Hook Result Serialization
+
+The system SHALL correctly serialize HookResult with updated_input and decision fields to JSON for Claude Code consumption.
+
+#### Scenario: Serialization includes all fields
+- **GIVEN** a HookResult with decision = "ask", message = "Review this", and updated_input = { "command": "safe-cmd" }
+- **WHEN** the result is serialized to JSON
+- **THEN** the JSON SHALL include:
+  ```json
+  {
+    "decision": "ask",
+    "message": "Review this",
+    "blocked": false,
+    "system_prompt": null,
+    "updated_input": {
+      "command": "safe-cmd"
+    }
+  }
+  ```
+
+#### Scenario: Null fields omitted or null
+- **GIVEN** a HookResult with only `blocked: false` set
+- **WHEN** the result is serialized to JSON
+- **THEN** optional fields (decision, updated_input) SHALL be null or omitted
+- **AND** the JSON SHALL be valid for Claude Code consumption
+
+#### Scenario: Updated input preserves value types
+- **GIVEN** updated_input containing various types: string, number, boolean, array, object
+- **WHEN** the result is serialized and deserialized
+- **THEN** all value types SHALL be preserved correctly
+- **AND** no type coercion SHALL occur

--- a/spectr/changes/add-pretooluse-updatedinput-ask-support/tasks.md
+++ b/spectr/changes/add-pretooluse-updatedinput-ask-support/tasks.md
@@ -1,0 +1,132 @@
+# Implementation Tasks
+
+## Phase 1: Type System Updates
+
+### Task 1.1: Add updated_input field to HookResult
+- **Description**: Add optional `updated_input` field to HookResult struct
+- **Location**: `src/types.rs` (HookResult struct)
+- **Implementation**:
+  - Add field: `pub updated_input: Option<HashMap<String, serde_json::Value>>`
+  - Include doc comment explaining the field's purpose
+  - Update `success()`, `blocked()`, and `with_context()` constructors to set `updated_input: None`
+- **Validation**: Code compiles without errors
+
+### Task 1.2: Add decision field to HookResult
+- **Description**: Add optional `decision` field for explicit permission decisions
+- **Location**: `src/types.rs` (HookResult struct)
+- **Implementation**:
+  - Add field: `pub decision: Option<String>`
+  - Include doc comment explaining valid values: "allow", "deny", "ask"
+  - Update constructors to set `decision: None`
+- **Validation**: Code compiles without errors
+
+### Task 1.3: Add HookResult constructor for ask with updated_input
+- **Description**: Create helper method for creating ask response with modified input
+- **Location**: `src/types.rs` (HookResult impl)
+- **Implementation**:
+  - Add method: `pub fn ask_with_input(reason: impl Into<String>, updated_input: HashMap<String, serde_json::Value>) -> Self`
+  - Sets decision to "ask", message to reason, and updated_input to provided value
+- **Validation**: Method can be called and returns correct struct
+
+## Phase 2: Hook Handler Updates
+
+### Task 2.1: Update PreToolUse handler to support ask decision
+- **Description**: Modify handle_pre_tool_use to recognize and handle ask decisions
+- **Location**: `src/hooks.rs` (handle_pre_tool_use function)
+- **Implementation**:
+  - When returning HookResult, check if decision is "ask"
+  - Serialize updated_input in response if present
+  - Ensure backward compatibility with existing blocked/success flow
+- **Validation**: PreToolUse hook correctly outputs ask decision with updated_input
+
+### Task 2.2: Update handle_hook_result to support ask decision
+- **Description**: Modify result handler to process ask decisions correctly
+- **Location**: `src/hooks.rs` (handle_hook_result function)
+- **Implementation**:
+  - Add case for decision = "ask" (different from blocked)
+  - Output JSON with decision, message, and updated_input fields
+  - Exit with appropriate code (0 for ask, different from blocked exit code 2)
+- **Validation**: Ask decisions produce correct JSON output
+
+## Phase 3: Testing
+
+### Task 3.1: Test HookResult serialization with updated_input
+- **Description**: Verify HookResult serializes correctly with updated_input field
+- **Location**: `src/types.rs` (in #[cfg(test)] module)
+- **Implementation**:
+  - Create HookResult with updated_input containing command modification
+  - Serialize to JSON
+  - Assert JSON contains "updated_input" with expected values
+- **Validation**: Test passes
+
+### Task 3.2: Test HookResult serialization with decision field
+- **Description**: Verify HookResult serializes correctly with decision field
+- **Location**: `src/types.rs` (in #[cfg(test)] module)
+- **Implementation**:
+  - Create HookResult with decision = "ask"
+  - Serialize to JSON
+  - Assert JSON contains "decision": "ask"
+- **Validation**: Test passes
+
+### Task 3.3: Test ask_with_input constructor
+- **Description**: Verify the new constructor creates correct HookResult
+- **Location**: `src/types.rs` (in #[cfg(test)] module)
+- **Implementation**:
+  - Call ask_with_input with reason and modified command
+  - Assert decision is "ask"
+  - Assert message contains reason
+  - Assert updated_input contains modified values
+- **Validation**: Test passes
+
+### Task 3.4: Test backward compatibility
+- **Description**: Verify existing hook results still work correctly
+- **Location**: `src/types.rs` (in #[cfg(test)] module)
+- **Implementation**:
+  - Verify HookResult::success() still works
+  - Verify HookResult::blocked() still works
+  - Verify HookResult::with_context() still works
+  - Assert new fields are None in these cases
+- **Validation**: All existing tests pass
+
+## Phase 4: Validation and Documentation
+
+### Task 4.1: Run cargo test
+- **Description**: Verify all tests pass including new updated_input tests
+- **Command**: `cargo test`
+- **Validation**: All tests pass
+
+### Task 4.2: Run cargo clippy
+- **Description**: Verify no new linting warnings introduced
+- **Command**: `cargo clippy -- -D warnings`
+- **Validation**: No warnings
+
+### Task 4.3: Update inline documentation
+- **Description**: Verify doc comments accurately describe new fields
+- **Location**: `src/types.rs` (HookResult struct)
+- **Implementation**:
+  - Document updated_input field and its purpose
+  - Document decision field and valid values
+  - Document ask_with_input constructor usage
+- **Validation**: Documentation is clear and accurate
+
+### Task 4.4: Validate with spectr
+- **Description**: Run spectr validation to ensure proposal is properly formed
+- **Command**: `spectr validate add-pretooluse-updatedinput-ask-support`
+- **Validation**: No validation errors
+
+## Task Dependencies
+- Task 1.2 can run in parallel with 1.1
+- Task 1.3 requires completion of 1.1 and 1.2
+- Phase 2 requires completion of Phase 1
+- Phase 3 requires completion of Phase 2
+- Phase 4 requires completion of Phase 3
+
+## Success Criteria
+- [ ] updated_input field added to HookResult
+- [ ] decision field added to HookResult
+- [ ] ask_with_input constructor added
+- [ ] PreToolUse handler supports ask with updated_input
+- [ ] All new tests pass
+- [ ] cargo test passes
+- [ ] cargo clippy passes with no warnings
+- [ ] spectr validate passes


### PR DESCRIPTION
## Summary

Proposal for review: `add-pretooluse-updatedinput-ask-support`

**Location**: `spectr/changes/add-pretooluse-updatedinput-ask-support/`

## Files

- `proposal.md` - Change overview
- `tasks.md` - Implementation checklist
- `specs/` - Delta specifications

## Review Checklist

- [ ] Proposal addresses the stated problem
- [ ] Delta specs are properly formatted
- [ ] Tasks are clear and actionable

---
*Generated by `spectr pr proposal`*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * PreToolUse hooks can now return modified input parameters alongside a decision (allow, deny, or ask for user confirmation).

* **Documentation**
  * Added specification detailing PreToolUse hook support for modified inputs, decision handling, serialization requirements, and backward compatibility.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->