### PR TITLE
spectr(proposal): allow-nil-userpromptsubmit-prompt

### DIFF
--- a/spectr/changes/allow-nil-userpromptsubmit-prompt/proposal.md
+++ b/spectr/changes/allow-nil-userpromptsubmit-prompt/proposal.md
@@ -1,0 +1,56 @@
+# Change: Allow nil prompt field in UserPromptSubmit hook payload
+
+## Why
+
+Issue #227 reports that Claude Code sometimes sends a `UserPromptSubmit` hook event with a `null` (nil) `prompt` field instead of an empty string or valid prompt text. This causes conclaude to fail validation with "Missing required field: prompt", blocking the hook and preventing Claude Code from proceeding.
+
+Rather than failing hard on a nil prompt, conclaude should gracefully handle this case by treating a nil prompt as valid input (just with no content to process) and allowing the hook to succeed without error.
+
+## What Changes
+
+### Modified Behavior: UserPromptSubmit Prompt Field
+
+The `prompt` field in `UserPromptSubmitPayload` will change from a required non-empty `String` to an `Option<String>` that accepts `null` values.
+
+**Before:**
+- `prompt: String` (required, must be non-empty)
+- Validation fails if prompt is missing or empty
+- Hook returns error: "Missing required field: prompt"
+
+**After:**
+- `prompt: Option<String>` (optional, can be null)
+- Validation succeeds even if prompt is null or empty
+- Hook processes with nil prompt gracefully (no context injection, no command execution)
+
+### Configuration Examples
+
+With nil prompt, the UserPromptSubmit hook will:
+1. Pass validation (no longer required)
+2. Skip context rule matching (nil prompt cannot match patterns)
+3. Skip command execution (no prompt to match against)
+4. Return success with no side effects
+5. Allow Claude Code to proceed normally
+
+## Impact
+
+- Affected specs: `hook-payloads`
+- Affected code: `src/types.rs`, `src/hooks.rs`
+- Breaking changes: None (makes validation more lenient, not stricter)
+- Compatibility: Fixes interoperability with Claude Code's hook payload format
+
+## Technical Notes
+
+The `UserPromptSubmitPayload.prompt` field will be deserializable as `null`, allowing serde to silently accept JSON like:
+```json
+{
+  "session_id": "...",
+  "transcript_path": "...",
+  "hook_event_name": "UserPromptSubmit",
+  "cwd": "...",
+  "prompt": null
+}
+```
+
+Handler logic remains unchanged:
+- If prompt is null or empty, context rules and commands simply don't execute
+- No special error handling needed; Option type provides safe defaults

--- a/spectr/changes/allow-nil-userpromptsubmit-prompt/specs/hook-payloads/spec.md
+++ b/spectr/changes/allow-nil-userpromptsubmit-prompt/specs/hook-payloads/spec.md
@@ -1,0 +1,70 @@
+# hook-payloads Specification Delta
+
+## ADDED Requirements
+
+### Requirement: UserPromptSubmit Payload Structure with Optional Prompt
+
+The system SHALL support `UserPromptSubmitPayload` with an optional `prompt` field that accepts null values without validation failure.
+
+#### Scenario: UserPromptSubmit with null prompt
+- **GIVEN** Claude Code sends a UserPromptSubmit hook event with `"prompt": null`
+- **WHEN** the payload is deserialized into UserPromptSubmitPayload
+- **THEN** deserialization SHALL succeed
+- **AND** the prompt field SHALL be `None` (Option type)
+- **AND** the hook handler SHALL return success without error
+
+#### Scenario: UserPromptSubmit with nil/missing prompt in JSON
+- **GIVEN** Claude Code sends a UserPromptSubmit hook event with missing prompt field
+- **WHEN** the payload is deserialized into UserPromptSubmitPayload
+- **THEN** deserialization SHALL fail (serde requires the field to exist)
+- **AND** an appropriate error SHALL indicate the missing field
+- **NOTE** Claude Code should always include the prompt field; if it doesn't, that's a Claude Code issue
+
+#### Scenario: UserPromptSubmit with empty string prompt
+- **GIVEN** Claude Code sends a UserPromptSubmit hook event with `"prompt": ""`
+- **WHEN** the payload is deserialized into UserPromptSubmitPayload
+- **THEN** deserialization SHALL succeed
+- **AND** the prompt field SHALL be `Some("")`
+- **AND** the hook handler SHALL return success without error
+
+#### Scenario: UserPromptSubmit with valid prompt text
+- **GIVEN** Claude Code sends a UserPromptSubmit hook event with `"prompt": "actual prompt text"`
+- **WHEN** the payload is deserialized into UserPromptSubmitPayload
+- **THEN** deserialization SHALL succeed
+- **AND** the prompt field SHALL be `Some("actual prompt text")`
+- **AND** the hook handler SHALL process normally (context rules, commands)
+
+#### Scenario: Hook handler graceful degradation with nil prompt
+- **GIVEN** a UserPromptSubmit hook handler receives a payload with `prompt: None`
+- **WHEN** evaluating context rules and commands
+- **THEN** context rules SHALL NOT match (nil cannot match patterns)
+- **AND** commands SHALL NOT be collected (nil has no content to match)
+- **AND** the handler SHALL return HookResult::success()
+- **AND** the hook SHALL NOT block Claude Code operation
+
+#### Scenario: Round-trip serialization with null prompt
+- **GIVEN** a UserPromptSubmitPayload with `prompt: None`
+- **WHEN** the payload is serialized to JSON and then deserialized back
+- **THEN** the JSON SHALL include `"prompt": null`
+- **AND** the deserialized payload SHALL have `prompt: None`
+- **AND** no data SHALL be lost in the round-trip
+
+### Requirement: UserPromptSubmit Hook Handler Graceful Degradation
+
+The `handle_user_prompt_submit()` hook handler SHALL process without error even when the prompt is null or empty.
+
+#### Scenario: Handler succeeds with nil prompt
+- **GIVEN** a UserPromptSubmit hook handler receives a payload with `prompt: None`
+- **WHEN** the handler executes `handle_user_prompt_submit()`
+- **THEN** it SHALL return HookResult::success()
+- **AND** it SHALL NOT return an error with "Missing required field: prompt"
+- **AND** context rules SHALL NOT be evaluated (nil prompt cannot match patterns)
+- **AND** commands SHALL NOT be executed (nil prompt has no content to match)
+
+#### Scenario: Handler succeeds with empty string prompt
+- **GIVEN** a UserPromptSubmit hook handler receives a payload with `prompt: Some("")`
+- **WHEN** the handler executes `handle_user_prompt_submit()`
+- **THEN** it SHALL return HookResult::success()
+- **AND** it SHALL NOT return an error
+- **AND** context rules SHALL NOT be evaluated (empty string cannot match patterns)
+- **AND** commands SHALL NOT be executed (empty prompt has no content to match)

--- a/spectr/changes/allow-nil-userpromptsubmit-prompt/tasks.md
+++ b/spectr/changes/allow-nil-userpromptsubmit-prompt/tasks.md
@@ -1,0 +1,27 @@
+# Implementation Checklist
+
+## Phase 1: Type System Updates
+
+- [ ] Update `UserPromptSubmitPayload.prompt` field from `String` to `Option<String>` in `src/types.rs`
+- [ ] Remove the prompt empty validation check in `handle_user_prompt_submit()` in `src/hooks.rs` (line 1279-1281)
+- [ ] Add unit tests for nil prompt deserialization in `src/types.rs`
+- [ ] Add unit tests for nil prompt handling in hook execution
+
+## Phase 2: Hook Handler Logic
+
+- [ ] Update context rule matching to handle nil/empty prompt gracefully
+- [ ] Update command collection logic to handle nil/empty prompt gracefully
+- [ ] Verify error messages don't reference required prompt field
+- [ ] Test hook returns success for nil prompt without errors
+
+## Phase 3: Validation & Testing
+
+- [ ] Run `cargo test` to verify all tests pass
+- [ ] Test with actual nil prompt JSON payload
+- [ ] Verify hook doesn't block Claude Code when prompt is null
+- [ ] Ensure no regressions for non-nil prompts
+
+## Phase 4: Documentation
+
+- [ ] Update spec with new requirements and scenarios for nil prompt handling
+- [ ] Verify no other code paths assume prompt is non-null


### PR DESCRIPTION
## Summary

Proposal for review: `allow-nil-userpromptsubmit-prompt`

**Location**: `spectr/changes/allow-nil-userpromptsubmit-prompt/`

## Files

- `proposal.md` - Change overview
- `tasks.md` - Implementation checklist
- `specs/` - Delta specifications

## Review Checklist

- [ ] Proposal addresses the stated problem
- [ ] Delta specs are properly formatted
- [ ] Tasks are clear and actionable

---
*Generated by `spectr pr proposal`*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * UserPromptSubmit hook now supports optional prompts; processing gracefully handles nil or empty values without context rules or command execution.

* **Documentation**
  * Added specification documents detailing payload validation and hook handler behavior across various prompt states and deserialization scenarios.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->