### PR TITLE
feat: add CwdChanged, FileChanged, InstructionsLoaded, PostCompact hooks

### DIFF
--- a/conclaude-schema.json
+++ b/conclaude-schema.json
@@ -132,6 +132,288 @@
       ],
       "type": "object"
     },
+    "CwdChangedCommand": {
+      "additionalProperties": false,
+      "description": "Configuration for individual cwd-changed commands with optional messages.",
+      "properties": {
+        "maxOutputLines": {
+          "default": null,
+          "description": "Maximum number of output lines to display (limits both stdout and stderr). Range: 1-10000",
+          "format": "uint32",
+          "maximum": 10000.0,
+          "minimum": 1.0,
+          "type": [
+            "integer",
+            "null"
+          ]
+        },
+        "message": {
+          "default": null,
+          "description": "Custom error message to display when the command fails (exits with non-zero status)",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "notifyPerCommand": {
+          "default": null,
+          "description": "Whether to send individual notifications for this command. Default: false",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "run": {
+          "description": "The shell command to execute. Environment variables are available: CONCLAUDE_OLD_CWD, CONCLAUDE_NEW_CWD, CONCLAUDE_SESSION_ID, CONCLAUDE_TRANSCRIPT_PATH, CONCLAUDE_HOOK_EVENT, CONCLAUDE_CWD, CONCLAUDE_CONFIG_DIR",
+          "type": "string"
+        },
+        "showCommand": {
+          "default": true,
+          "description": "Whether to show the command being executed to the user and Claude. Default: true",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "showStderr": {
+          "default": null,
+          "description": "Whether to show the command's standard error output to the user and Claude. Default: false",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "showStdout": {
+          "default": null,
+          "description": "Whether to show the command's standard output to the user and Claude. Default: false",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "timeout": {
+          "default": null,
+          "description": "Optional command timeout in seconds. Range: 1-3600 (1 second to 1 hour).",
+          "format": "uint64",
+          "maximum": 3600.0,
+          "minimum": 1.0,
+          "type": [
+            "integer",
+            "null"
+          ]
+        }
+      },
+      "required": [
+        "run"
+      ],
+      "type": "object"
+    },
+    "CwdChangedConfig": {
+      "additionalProperties": false,
+      "description": "Configuration for cwd-changed hooks with path-based command execution.\n\nCommands run when the working directory changes. Observational.",
+      "properties": {
+        "commands": {
+          "additionalProperties": {
+            "items": {
+              "$ref": "#/definitions/CwdChangedCommand"
+            },
+            "type": "array"
+          },
+          "default": {},
+          "description": "Map of new-cwd patterns to command configurations. Keys are glob patterns matched against the new working directory (e.g., \"*\", \"/home/**\").",
+          "type": "object"
+        }
+      },
+      "type": "object"
+    },
+    "FileChangedCommand": {
+      "additionalProperties": false,
+      "description": "Configuration for individual file-changed commands with optional messages.",
+      "properties": {
+        "maxOutputLines": {
+          "default": null,
+          "description": "Maximum number of output lines to display (limits both stdout and stderr). Range: 1-10000",
+          "format": "uint32",
+          "maximum": 10000.0,
+          "minimum": 1.0,
+          "type": [
+            "integer",
+            "null"
+          ]
+        },
+        "message": {
+          "default": null,
+          "description": "Custom error message to display when the command fails (exits with non-zero status)",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "notifyPerCommand": {
+          "default": null,
+          "description": "Whether to send individual notifications for this command. Default: false",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "run": {
+          "description": "The shell command to execute. Environment variables are available: CONCLAUDE_FILE_PATH, CONCLAUDE_FILE_EVENT, CONCLAUDE_SESSION_ID, CONCLAUDE_TRANSCRIPT_PATH, CONCLAUDE_HOOK_EVENT, CONCLAUDE_CWD, CONCLAUDE_CONFIG_DIR",
+          "type": "string"
+        },
+        "showCommand": {
+          "default": true,
+          "description": "Whether to show the command being executed to the user and Claude. Default: true",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "showStderr": {
+          "default": null,
+          "description": "Whether to show the command's standard error output to the user and Claude. Default: false",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "showStdout": {
+          "default": null,
+          "description": "Whether to show the command's standard output to the user and Claude. Default: false",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "timeout": {
+          "default": null,
+          "description": "Optional command timeout in seconds. Range: 1-3600 (1 second to 1 hour).",
+          "format": "uint64",
+          "maximum": 3600.0,
+          "minimum": 1.0,
+          "type": [
+            "integer",
+            "null"
+          ]
+        }
+      },
+      "required": [
+        "run"
+      ],
+      "type": "object"
+    },
+    "FileChangedConfig": {
+      "additionalProperties": false,
+      "description": "Configuration for file-changed hooks with path-based command execution.\n\nCommands run when a watched file changes on disk. Observational.",
+      "properties": {
+        "commands": {
+          "additionalProperties": {
+            "items": {
+              "$ref": "#/definitions/FileChangedCommand"
+            },
+            "type": "array"
+          },
+          "default": {},
+          "description": "Map of file-path patterns to command configurations. Keys are glob patterns matched against the changed file path (e.g., \"*.rs\", \"src/**\", \"*\").",
+          "type": "object"
+        }
+      },
+      "type": "object"
+    },
+    "InstructionsLoadedCommand": {
+      "additionalProperties": false,
+      "description": "Configuration for individual instructions-loaded commands with optional messages.",
+      "properties": {
+        "maxOutputLines": {
+          "default": null,
+          "description": "Maximum number of output lines to display (limits both stdout and stderr). Range: 1-10000",
+          "format": "uint32",
+          "maximum": 10000.0,
+          "minimum": 1.0,
+          "type": [
+            "integer",
+            "null"
+          ]
+        },
+        "message": {
+          "default": null,
+          "description": "Custom error message to display when the command fails (exits with non-zero status)",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "notifyPerCommand": {
+          "default": null,
+          "description": "Whether to send individual notifications for this command. Default: false",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "run": {
+          "description": "The shell command to execute. Environment variables are available: CONCLAUDE_INSTRUCTIONS_FILE_PATH, CONCLAUDE_MEMORY_TYPE, CONCLAUDE_LOAD_REASON, CONCLAUDE_SESSION_ID, CONCLAUDE_TRANSCRIPT_PATH, CONCLAUDE_HOOK_EVENT, CONCLAUDE_CWD, CONCLAUDE_CONFIG_DIR",
+          "type": "string"
+        },
+        "showCommand": {
+          "default": true,
+          "description": "Whether to show the command being executed to the user and Claude. Default: true",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "showStderr": {
+          "default": null,
+          "description": "Whether to show the command's standard error output to the user and Claude. Default: false",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "showStdout": {
+          "default": null,
+          "description": "Whether to show the command's standard output to the user and Claude. Default: false",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "timeout": {
+          "default": null,
+          "description": "Optional command timeout in seconds. Range: 1-3600 (1 second to 1 hour).",
+          "format": "uint64",
+          "maximum": 3600.0,
+          "minimum": 1.0,
+          "type": [
+            "integer",
+            "null"
+          ]
+        }
+      },
+      "required": [
+        "run"
+      ],
+      "type": "object"
+    },
+    "InstructionsLoadedConfig": {
+      "additionalProperties": false,
+      "description": "Configuration for instructions-loaded hooks with command execution.\n\nCommands run when Claude Code loads an instructions/memory file. Observational.",
+      "properties": {
+        "commands": {
+          "additionalProperties": {
+            "items": {
+              "$ref": "#/definitions/InstructionsLoadedCommand"
+            },
+            "type": "array"
+          },
+          "default": {},
+          "description": "Map of memory-type patterns to command configurations. Keys are glob patterns matched against the memory type (e.g., \"User\", \"Project\", \"*\").",
+          "type": "object"
+        }
+      },
+      "type": "object"
+    },
     "NotificationsConfig": {
       "additionalProperties": false,
       "description": "Configuration for system notifications.\n\nControls desktop notifications for hook execution, errors, successes, and system events. Notifications help you stay informed about what conclaude is doing in the background.\n\n# Examples\n\n```yaml # Enable notifications for all hooks notifications: enabled: true hooks: [\"*\"] showErrors: true showSuccess: true showSystemEvents: true ```\n\n```yaml # Enable notifications only for Stop hook notifications: enabled: true hooks: [\"Stop\"] showErrors: true showSuccess: false showSystemEvents: false ```\n\n```yaml # Enable notifications for specific hooks notifications: enabled: true hooks: [\"Stop\", \"PreToolUse\"] showErrors: true showSuccess: true showSystemEvents: true ```",
@@ -201,6 +483,100 @@
       "required": [
         "default"
       ],
+      "type": "object"
+    },
+    "PostCompactCommand": {
+      "additionalProperties": false,
+      "description": "Configuration for individual post-compact commands with optional messages.",
+      "properties": {
+        "maxOutputLines": {
+          "default": null,
+          "description": "Maximum number of output lines to display (limits both stdout and stderr). Range: 1-10000",
+          "format": "uint32",
+          "maximum": 10000.0,
+          "minimum": 1.0,
+          "type": [
+            "integer",
+            "null"
+          ]
+        },
+        "message": {
+          "default": null,
+          "description": "Custom error message to display when the command fails (exits with non-zero status)",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "notifyPerCommand": {
+          "default": null,
+          "description": "Whether to send individual notifications for this command. Default: false",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "run": {
+          "description": "The shell command to execute. Environment variables are available: CONCLAUDE_COMPACT_TRIGGER, CONCLAUDE_COMPACT_SUMMARY, CONCLAUDE_SESSION_ID, CONCLAUDE_TRANSCRIPT_PATH, CONCLAUDE_HOOK_EVENT, CONCLAUDE_CWD, CONCLAUDE_CONFIG_DIR",
+          "type": "string"
+        },
+        "showCommand": {
+          "default": true,
+          "description": "Whether to show the command being executed to the user and Claude. Default: true",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "showStderr": {
+          "default": null,
+          "description": "Whether to show the command's standard error output to the user and Claude. Default: false",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "showStdout": {
+          "default": null,
+          "description": "Whether to show the command's standard output to the user and Claude. Default: false",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "timeout": {
+          "default": null,
+          "description": "Optional command timeout in seconds. Range: 1-3600 (1 second to 1 hour).",
+          "format": "uint64",
+          "maximum": 3600.0,
+          "minimum": 1.0,
+          "type": [
+            "integer",
+            "null"
+          ]
+        }
+      },
+      "required": [
+        "run"
+      ],
+      "type": "object"
+    },
+    "PostCompactConfig": {
+      "additionalProperties": false,
+      "description": "Configuration for post-compact hooks with trigger-based command execution.\n\nCommands run after transcript compaction completes. Observational - the trigger value (\"manual\" or \"auto\") is used as the match query.",
+      "properties": {
+        "commands": {
+          "additionalProperties": {
+            "items": {
+              "$ref": "#/definitions/PostCompactCommand"
+            },
+            "type": "array"
+          },
+          "default": {},
+          "description": "Map of trigger patterns to command configurations. Keys are glob patterns matching the compaction trigger (e.g., \"manual\", \"auto\", \"*\").",
+          "type": "object"
+        }
+      },
       "type": "object"
     },
     "PreToolUseConfig": {
@@ -1185,6 +1561,39 @@
       },
       "description": "Configuration for config change hooks"
     },
+    "cwdChanged": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/CwdChangedConfig"
+        }
+      ],
+      "default": {
+        "commands": {}
+      },
+      "description": "Configuration for cwd-changed hooks that run when the working directory changes."
+    },
+    "fileChanged": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/FileChangedConfig"
+        }
+      ],
+      "default": {
+        "commands": {}
+      },
+      "description": "Configuration for file-changed hooks that run when a watched file changes."
+    },
+    "instructionsLoaded": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/InstructionsLoadedConfig"
+        }
+      ],
+      "default": {
+        "commands": {}
+      },
+      "description": "Configuration for instructions-loaded hooks that run when an instructions/memory file loads."
+    },
     "notifications": {
       "allOf": [
         {
@@ -1209,6 +1618,17 @@
         }
       ],
       "default": null
+    },
+    "postCompact": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/PostCompactConfig"
+        }
+      ],
+      "default": {
+        "commands": {}
+      },
+      "description": "Configuration for post-compact hooks that run after transcript compaction."
     },
     "preToolUse": {
       "allOf": [

--- a/docs/src/content/docs/reference/config/configuration.md
+++ b/docs/src/content/docs/reference/config/configuration.md
@@ -14,8 +14,12 @@ Conclaude uses YAML configuration files to define lifecycle hooks, file protecti
 | Section | Description | Key Options |
 |---------|-------------|-------------|
 | [Config Change](/conclaude/reference/config/config-change) | Configuration for config change hooks with source-based command execution | `commands` |
+| [Cwd Changed](/conclaude/reference/config/cwd-changed) | Configuration for cwd-changed hooks with path-based command execution | `commands` |
+| [File Changed](/conclaude/reference/config/file-changed) | Configuration for file-changed hooks with path-based command execution | `commands` |
+| [Instructions Loaded](/conclaude/reference/config/instructions-loaded) | Configuration for instructions-loaded hooks with command execution | `commands` |
 | [Notifications](/conclaude/reference/config/notifications) | Configuration for system notifications | `enabled`, `hooks`, `showErrors` |
 | [Permission Request](/conclaude/reference/config/permission-request) | Configuration for permission request hooks that control tool permission decisions | `allow`, `default`, `deny` |
+| [Post Compact](/conclaude/reference/config/post-compact) | Configuration for post-compact hooks with trigger-based command execution | `commands` |
 | [Pre Tool Use](/conclaude/reference/config/pre-tool-use) | Configuration for pre-tool-use hooks that run before tools are executed | `preventAdditions`, `preventRootAdditions`, `preventRootAdditionsMessage` |
 | [Setup](/conclaude/reference/config/setup) | Configuration for setup hooks with trigger-based command execution | `commands` |
 | [Skill Start](/conclaude/reference/config/skill-start) | Configuration for skill start hooks that trigger when subagents (skills) start | `commands` |
@@ -35,6 +39,18 @@ Detailed documentation for each configuration section:
 
 Configuration for config change hooks with source-based command execution.
 
+### [Cwd Changed](/conclaude/reference/config/cwd-changed)
+
+Configuration for cwd-changed hooks with path-based command execution.
+
+### [File Changed](/conclaude/reference/config/file-changed)
+
+Configuration for file-changed hooks with path-based command execution.
+
+### [Instructions Loaded](/conclaude/reference/config/instructions-loaded)
+
+Configuration for instructions-loaded hooks with command execution.
+
 ### [Notifications](/conclaude/reference/config/notifications)
 
 Configuration for system notifications.
@@ -42,6 +58,10 @@ Configuration for system notifications.
 ### [Permission Request](/conclaude/reference/config/permission-request)
 
 Configuration for permission request hooks that control tool permission decisions.
+
+### [Post Compact](/conclaude/reference/config/post-compact)
+
+Configuration for post-compact hooks with trigger-based command execution.
 
 ### [Pre Tool Use](/conclaude/reference/config/pre-tool-use)
 

--- a/docs/src/content/docs/reference/config/cwd-changed.md
+++ b/docs/src/content/docs/reference/config/cwd-changed.md
@@ -1,0 +1,46 @@
+---
+title: Cwd Changed
+description: Configuration options for cwdChanged
+---
+
+# Cwd Changed
+
+Configuration for cwd-changed hooks with path-based command execution.
+
+Commands run when the working directory changes. Observational.
+
+## Configuration Properties
+
+### `commands`
+
+Map of new-cwd patterns to command configurations. Keys are glob patterns matched against the new working directory (e.g., "*", "/home/**").
+
+| Attribute | Value |
+|-----------|-------|
+| **Type** | `object` |
+| **Default** | `{}` |
+
+## Nested Types
+
+This section uses the following nested type definitions:
+
+### `CwdChangedCommand` Type
+
+Configuration for individual cwd-changed commands with optional messages.
+
+**Properties:**
+
+| Property | Type | Default | Description |
+|----------|------|---------|-------------|
+| `maxOutputLines` | `integer | null` | `null` | Maximum number of output lines to display (limits both stdout and stderr) |
+| `message` | `string | null` | `null` | Custom error message to display when the command fails (exits with non-zero status) |
+| `notifyPerCommand` | `boolean | null` | `null` | Whether to send individual notifications for this command |
+| `run` | `string` | - | The shell command to execute |
+| `showCommand` | `boolean | null` | `true` | Whether to show the command being executed to the user and Claude |
+| `showStderr` | `boolean | null` | `null` | Whether to show the command's standard error output to the user and Claude |
+| `showStdout` | `boolean | null` | `null` | Whether to show the command's standard output to the user and Claude |
+| `timeout` | `integer | null` | `null` | Optional command timeout in seconds |
+
+## See Also
+
+- [Configuration Overview](/conclaude/reference/config/configuration) - Complete reference for all configuration options

--- a/docs/src/content/docs/reference/config/file-changed.md
+++ b/docs/src/content/docs/reference/config/file-changed.md
@@ -1,0 +1,46 @@
+---
+title: File Changed
+description: Configuration options for fileChanged
+---
+
+# File Changed
+
+Configuration for file-changed hooks with path-based command execution.
+
+Commands run when a watched file changes on disk. Observational.
+
+## Configuration Properties
+
+### `commands`
+
+Map of file-path patterns to command configurations. Keys are glob patterns matched against the changed file path (e.g., "*.rs", "src/**", "*").
+
+| Attribute | Value |
+|-----------|-------|
+| **Type** | `object` |
+| **Default** | `{}` |
+
+## Nested Types
+
+This section uses the following nested type definitions:
+
+### `FileChangedCommand` Type
+
+Configuration for individual file-changed commands with optional messages.
+
+**Properties:**
+
+| Property | Type | Default | Description |
+|----------|------|---------|-------------|
+| `maxOutputLines` | `integer | null` | `null` | Maximum number of output lines to display (limits both stdout and stderr) |
+| `message` | `string | null` | `null` | Custom error message to display when the command fails (exits with non-zero status) |
+| `notifyPerCommand` | `boolean | null` | `null` | Whether to send individual notifications for this command |
+| `run` | `string` | - | The shell command to execute |
+| `showCommand` | `boolean | null` | `true` | Whether to show the command being executed to the user and Claude |
+| `showStderr` | `boolean | null` | `null` | Whether to show the command's standard error output to the user and Claude |
+| `showStdout` | `boolean | null` | `null` | Whether to show the command's standard output to the user and Claude |
+| `timeout` | `integer | null` | `null` | Optional command timeout in seconds |
+
+## See Also
+
+- [Configuration Overview](/conclaude/reference/config/configuration) - Complete reference for all configuration options

--- a/docs/src/content/docs/reference/config/instructions-loaded.md
+++ b/docs/src/content/docs/reference/config/instructions-loaded.md
@@ -1,0 +1,46 @@
+---
+title: Instructions Loaded
+description: Configuration options for instructionsLoaded
+---
+
+# Instructions Loaded
+
+Configuration for instructions-loaded hooks with command execution.
+
+Commands run when Claude Code loads an instructions/memory file. Observational.
+
+## Configuration Properties
+
+### `commands`
+
+Map of memory-type patterns to command configurations. Keys are glob patterns matched against the memory type (e.g., "User", "Project", "*").
+
+| Attribute | Value |
+|-----------|-------|
+| **Type** | `object` |
+| **Default** | `{}` |
+
+## Nested Types
+
+This section uses the following nested type definitions:
+
+### `InstructionsLoadedCommand` Type
+
+Configuration for individual instructions-loaded commands with optional messages.
+
+**Properties:**
+
+| Property | Type | Default | Description |
+|----------|------|---------|-------------|
+| `maxOutputLines` | `integer | null` | `null` | Maximum number of output lines to display (limits both stdout and stderr) |
+| `message` | `string | null` | `null` | Custom error message to display when the command fails (exits with non-zero status) |
+| `notifyPerCommand` | `boolean | null` | `null` | Whether to send individual notifications for this command |
+| `run` | `string` | - | The shell command to execute |
+| `showCommand` | `boolean | null` | `true` | Whether to show the command being executed to the user and Claude |
+| `showStderr` | `boolean | null` | `null` | Whether to show the command's standard error output to the user and Claude |
+| `showStdout` | `boolean | null` | `null` | Whether to show the command's standard output to the user and Claude |
+| `timeout` | `integer | null` | `null` | Optional command timeout in seconds |
+
+## See Also
+
+- [Configuration Overview](/conclaude/reference/config/configuration) - Complete reference for all configuration options

--- a/docs/src/content/docs/reference/config/post-compact.md
+++ b/docs/src/content/docs/reference/config/post-compact.md
@@ -1,0 +1,46 @@
+---
+title: Post Compact
+description: Configuration options for postCompact
+---
+
+# Post Compact
+
+Configuration for post-compact hooks with trigger-based command execution.
+
+Commands run after transcript compaction completes. Observational - the trigger value ("manual" or "auto") is used as the match query.
+
+## Configuration Properties
+
+### `commands`
+
+Map of trigger patterns to command configurations. Keys are glob patterns matching the compaction trigger (e.g., "manual", "auto", "*").
+
+| Attribute | Value |
+|-----------|-------|
+| **Type** | `object` |
+| **Default** | `{}` |
+
+## Nested Types
+
+This section uses the following nested type definitions:
+
+### `PostCompactCommand` Type
+
+Configuration for individual post-compact commands with optional messages.
+
+**Properties:**
+
+| Property | Type | Default | Description |
+|----------|------|---------|-------------|
+| `maxOutputLines` | `integer | null` | `null` | Maximum number of output lines to display (limits both stdout and stderr) |
+| `message` | `string | null` | `null` | Custom error message to display when the command fails (exits with non-zero status) |
+| `notifyPerCommand` | `boolean | null` | `null` | Whether to send individual notifications for this command |
+| `run` | `string` | - | The shell command to execute |
+| `showCommand` | `boolean | null` | `true` | Whether to show the command being executed to the user and Claude |
+| `showStderr` | `boolean | null` | `null` | Whether to show the command's standard error output to the user and Claude |
+| `showStdout` | `boolean | null` | `null` | Whether to show the command's standard output to the user and Claude |
+| `timeout` | `integer | null` | `null` | Optional command timeout in seconds |
+
+## See Also
+
+- [Configuration Overview](/conclaude/reference/config/configuration) - Complete reference for all configuration options

--- a/src/config.rs
+++ b/src/config.rs
@@ -525,6 +525,179 @@ pub struct SetupConfig {
     pub commands: std::collections::HashMap<String, Vec<SetupCommand>>,
 }
 
+/// Configuration for individual post-compact commands with optional messages.
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, FieldList)]
+#[serde(deny_unknown_fields)]
+pub struct PostCompactCommand {
+    /// The shell command to execute. Environment variables are available: CONCLAUDE_COMPACT_TRIGGER, CONCLAUDE_COMPACT_SUMMARY, CONCLAUDE_SESSION_ID, CONCLAUDE_TRANSCRIPT_PATH, CONCLAUDE_HOOK_EVENT, CONCLAUDE_CWD, CONCLAUDE_CONFIG_DIR
+    pub run: String,
+    /// Custom error message to display when the command fails (exits with non-zero status)
+    #[serde(default)]
+    pub message: Option<String>,
+    /// Whether to show the command being executed to the user and Claude. Default: true
+    #[serde(default = "default_option_true", rename = "showCommand")]
+    pub show_command: Option<bool>,
+    /// Whether to show the command's standard output to the user and Claude. Default: false
+    #[serde(default, rename = "showStdout")]
+    pub show_stdout: Option<bool>,
+    /// Whether to show the command's standard error output to the user and Claude. Default: false
+    #[serde(default, rename = "showStderr")]
+    pub show_stderr: Option<bool>,
+    /// Maximum number of output lines to display (limits both stdout and stderr). Range: 1-10000
+    #[serde(default, rename = "maxOutputLines")]
+    #[schemars(range(min = 1, max = 10000))]
+    pub max_output_lines: Option<u32>,
+    /// Optional command timeout in seconds. Range: 1-3600 (1 second to 1 hour).
+    #[serde(default)]
+    #[schemars(range(min = 1, max = 3600))]
+    pub timeout: Option<u64>,
+    /// Whether to send individual notifications for this command. Default: false
+    #[serde(default, rename = "notifyPerCommand")]
+    pub notify_per_command: Option<bool>,
+}
+
+/// Configuration for individual cwd-changed commands with optional messages.
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, FieldList)]
+#[serde(deny_unknown_fields)]
+pub struct CwdChangedCommand {
+    /// The shell command to execute. Environment variables are available: CONCLAUDE_OLD_CWD, CONCLAUDE_NEW_CWD, CONCLAUDE_SESSION_ID, CONCLAUDE_TRANSCRIPT_PATH, CONCLAUDE_HOOK_EVENT, CONCLAUDE_CWD, CONCLAUDE_CONFIG_DIR
+    pub run: String,
+    /// Custom error message to display when the command fails (exits with non-zero status)
+    #[serde(default)]
+    pub message: Option<String>,
+    /// Whether to show the command being executed to the user and Claude. Default: true
+    #[serde(default = "default_option_true", rename = "showCommand")]
+    pub show_command: Option<bool>,
+    /// Whether to show the command's standard output to the user and Claude. Default: false
+    #[serde(default, rename = "showStdout")]
+    pub show_stdout: Option<bool>,
+    /// Whether to show the command's standard error output to the user and Claude. Default: false
+    #[serde(default, rename = "showStderr")]
+    pub show_stderr: Option<bool>,
+    /// Maximum number of output lines to display (limits both stdout and stderr). Range: 1-10000
+    #[serde(default, rename = "maxOutputLines")]
+    #[schemars(range(min = 1, max = 10000))]
+    pub max_output_lines: Option<u32>,
+    /// Optional command timeout in seconds. Range: 1-3600 (1 second to 1 hour).
+    #[serde(default)]
+    #[schemars(range(min = 1, max = 3600))]
+    pub timeout: Option<u64>,
+    /// Whether to send individual notifications for this command. Default: false
+    #[serde(default, rename = "notifyPerCommand")]
+    pub notify_per_command: Option<bool>,
+}
+
+/// Configuration for individual file-changed commands with optional messages.
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, FieldList)]
+#[serde(deny_unknown_fields)]
+pub struct FileChangedCommand {
+    /// The shell command to execute. Environment variables are available: CONCLAUDE_FILE_PATH, CONCLAUDE_FILE_EVENT, CONCLAUDE_SESSION_ID, CONCLAUDE_TRANSCRIPT_PATH, CONCLAUDE_HOOK_EVENT, CONCLAUDE_CWD, CONCLAUDE_CONFIG_DIR
+    pub run: String,
+    /// Custom error message to display when the command fails (exits with non-zero status)
+    #[serde(default)]
+    pub message: Option<String>,
+    /// Whether to show the command being executed to the user and Claude. Default: true
+    #[serde(default = "default_option_true", rename = "showCommand")]
+    pub show_command: Option<bool>,
+    /// Whether to show the command's standard output to the user and Claude. Default: false
+    #[serde(default, rename = "showStdout")]
+    pub show_stdout: Option<bool>,
+    /// Whether to show the command's standard error output to the user and Claude. Default: false
+    #[serde(default, rename = "showStderr")]
+    pub show_stderr: Option<bool>,
+    /// Maximum number of output lines to display (limits both stdout and stderr). Range: 1-10000
+    #[serde(default, rename = "maxOutputLines")]
+    #[schemars(range(min = 1, max = 10000))]
+    pub max_output_lines: Option<u32>,
+    /// Optional command timeout in seconds. Range: 1-3600 (1 second to 1 hour).
+    #[serde(default)]
+    #[schemars(range(min = 1, max = 3600))]
+    pub timeout: Option<u64>,
+    /// Whether to send individual notifications for this command. Default: false
+    #[serde(default, rename = "notifyPerCommand")]
+    pub notify_per_command: Option<bool>,
+}
+
+/// Configuration for individual instructions-loaded commands with optional messages.
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, FieldList)]
+#[serde(deny_unknown_fields)]
+pub struct InstructionsLoadedCommand {
+    /// The shell command to execute. Environment variables are available: CONCLAUDE_INSTRUCTIONS_FILE_PATH, CONCLAUDE_MEMORY_TYPE, CONCLAUDE_LOAD_REASON, CONCLAUDE_SESSION_ID, CONCLAUDE_TRANSCRIPT_PATH, CONCLAUDE_HOOK_EVENT, CONCLAUDE_CWD, CONCLAUDE_CONFIG_DIR
+    pub run: String,
+    /// Custom error message to display when the command fails (exits with non-zero status)
+    #[serde(default)]
+    pub message: Option<String>,
+    /// Whether to show the command being executed to the user and Claude. Default: true
+    #[serde(default = "default_option_true", rename = "showCommand")]
+    pub show_command: Option<bool>,
+    /// Whether to show the command's standard output to the user and Claude. Default: false
+    #[serde(default, rename = "showStdout")]
+    pub show_stdout: Option<bool>,
+    /// Whether to show the command's standard error output to the user and Claude. Default: false
+    #[serde(default, rename = "showStderr")]
+    pub show_stderr: Option<bool>,
+    /// Maximum number of output lines to display (limits both stdout and stderr). Range: 1-10000
+    #[serde(default, rename = "maxOutputLines")]
+    #[schemars(range(min = 1, max = 10000))]
+    pub max_output_lines: Option<u32>,
+    /// Optional command timeout in seconds. Range: 1-3600 (1 second to 1 hour).
+    #[serde(default)]
+    #[schemars(range(min = 1, max = 3600))]
+    pub timeout: Option<u64>,
+    /// Whether to send individual notifications for this command. Default: false
+    #[serde(default, rename = "notifyPerCommand")]
+    pub notify_per_command: Option<bool>,
+}
+
+/// Configuration for post-compact hooks with trigger-based command execution.
+///
+/// Commands run after transcript compaction completes. Observational - the
+/// trigger value ("manual" or "auto") is used as the match query.
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, Default, FieldList)]
+#[serde(deny_unknown_fields)]
+pub struct PostCompactConfig {
+    /// Map of trigger patterns to command configurations.
+    /// Keys are glob patterns matching the compaction trigger (e.g., "manual", "auto", "*").
+    #[serde(default)]
+    pub commands: std::collections::HashMap<String, Vec<PostCompactCommand>>,
+}
+
+/// Configuration for cwd-changed hooks with path-based command execution.
+///
+/// Commands run when the working directory changes. Observational.
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, Default, FieldList)]
+#[serde(deny_unknown_fields)]
+pub struct CwdChangedConfig {
+    /// Map of new-cwd patterns to command configurations.
+    /// Keys are glob patterns matched against the new working directory (e.g., "*", "/home/**").
+    #[serde(default)]
+    pub commands: std::collections::HashMap<String, Vec<CwdChangedCommand>>,
+}
+
+/// Configuration for file-changed hooks with path-based command execution.
+///
+/// Commands run when a watched file changes on disk. Observational.
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, Default, FieldList)]
+#[serde(deny_unknown_fields)]
+pub struct FileChangedConfig {
+    /// Map of file-path patterns to command configurations.
+    /// Keys are glob patterns matched against the changed file path (e.g., "*.rs", "src/**", "*").
+    #[serde(default)]
+    pub commands: std::collections::HashMap<String, Vec<FileChangedCommand>>,
+}
+
+/// Configuration for instructions-loaded hooks with command execution.
+///
+/// Commands run when Claude Code loads an instructions/memory file. Observational.
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, Default, FieldList)]
+#[serde(deny_unknown_fields)]
+pub struct InstructionsLoadedConfig {
+    /// Map of memory-type patterns to command configurations.
+    /// Keys are glob patterns matched against the memory type (e.g., "User", "Project", "*").
+    #[serde(default)]
+    pub commands: std::collections::HashMap<String, Vec<InstructionsLoadedCommand>>,
+}
+
 /// Configuration for stop hook commands that run when Claude is about to stop
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, Default, FieldList)]
 #[serde(deny_unknown_fields)]
@@ -1340,6 +1513,18 @@ pub struct ConclaudeConfig {
     /// ```
     #[serde(default)]
     pub setup: SetupConfig,
+    /// Configuration for post-compact hooks that run after transcript compaction.
+    #[serde(default, rename = "postCompact")]
+    pub post_compact: PostCompactConfig,
+    /// Configuration for cwd-changed hooks that run when the working directory changes.
+    #[serde(default, rename = "cwdChanged")]
+    pub cwd_changed: CwdChangedConfig,
+    /// Configuration for file-changed hooks that run when a watched file changes.
+    #[serde(default, rename = "fileChanged")]
+    pub file_changed: FileChangedConfig,
+    /// Configuration for instructions-loaded hooks that run when an instructions/memory file loads.
+    #[serde(default, rename = "instructionsLoaded")]
+    pub instructions_loaded: InstructionsLoadedConfig,
 }
 
 /// Extract the field name from an unknown field error message

--- a/src/hooks.rs
+++ b/src/hooks.rs
@@ -1,15 +1,19 @@
 use crate::config::{
     extract_bash_commands, load_conclaude_config, ConclaudeConfig, ConfigChangeConfig,
-    SetupConfig, SkillStartConfig, SlashCommandConfig, SubagentStopConfig, TaskCompletedConfig,
+    CwdChangedConfig, FileChangedConfig, InstructionsLoadedConfig, PostCompactConfig, SetupConfig,
+    SkillStartConfig, SlashCommandConfig, SubagentStopConfig, TaskCompletedConfig,
     TeammateIdleConfig, UserPromptSubmitCommand,
 };
 use crate::gitignore::{find_git_root, is_path_git_ignored};
 use crate::types::{
-    validate_base_payload, validate_permission_request_payload, validate_setup_payload,
-    validate_stop_failure_payload, validate_subagent_start_payload, validate_subagent_stop_payload,
+    validate_base_payload, validate_cwd_changed_payload, validate_file_changed_payload,
+    validate_instructions_loaded_payload, validate_permission_request_payload,
+    validate_post_compact_payload, validate_setup_payload, validate_stop_failure_payload,
+    validate_subagent_start_payload, validate_subagent_stop_payload,
     validate_task_completed_payload, validate_teammate_idle_payload,
     validate_worktree_create_payload, validate_worktree_remove_payload, ConfigChangePayload,
-    ConfigChangeSource, HookResult, NotificationPayload, PermissionRequestPayload,
+    ConfigChangeSource, CwdChangedPayload, FileChangedPayload, HookResult,
+    InstructionsLoadedPayload, NotificationPayload, PermissionRequestPayload, PostCompactPayload,
     PostToolUseFailurePayload, PostToolUsePayload, PreCompactPayload, PreToolUsePayload,
     SessionEndPayload, SessionStartPayload, SetupPayload, StopFailurePayload, StopPayload,
     SubagentStartPayload, SubagentStopPayload, TaskCompletedPayload, TeammateIdlePayload,
@@ -200,6 +204,10 @@ pub(crate) fn is_system_event_hook(hook_name: &str) -> bool {
             | "WorktreeCreate"
             | "WorktreeRemove"
             | "Setup"
+            | "PostCompact"
+            | "CwdChanged"
+            | "FileChanged"
+            | "InstructionsLoaded"
     )
 }
 
@@ -4406,6 +4414,383 @@ fn build_setup_env_vars(payload: &SetupPayload, config_dir: &Path) -> HashMap<St
         env_vars.insert("CONCLAUDE_PAYLOAD_JSON".to_string(), json);
     }
     env_vars
+}
+
+/// Insert the shared base environment variables for a hook command.
+fn insert_base_env_vars<T: serde::Serialize>(
+    env_vars: &mut HashMap<String, String>,
+    base: &crate::types::BasePayload,
+    payload: &T,
+    hook_event: &str,
+    config_dir: &Path,
+) {
+    env_vars.insert("CONCLAUDE_SESSION_ID".to_string(), base.session_id.clone());
+    env_vars.insert(
+        "CONCLAUDE_TRANSCRIPT_PATH".to_string(),
+        base.transcript_path.clone(),
+    );
+    env_vars.insert("CONCLAUDE_HOOK_EVENT".to_string(), hook_event.to_string());
+    env_vars.insert("CONCLAUDE_CWD".to_string(), base.cwd.clone());
+    env_vars.insert(
+        "CONCLAUDE_CONFIG_DIR".to_string(),
+        config_dir.to_string_lossy().to_string(),
+    );
+    if let Ok(json) = serde_json::to_string(payload) {
+        env_vars.insert("CONCLAUDE_PAYLOAD_JSON".to_string(), json);
+    }
+}
+
+/// Collect commands from `PostCompactConfig` for matching patterns.
+fn collect_post_compact_commands(
+    config: &PostCompactConfig,
+    matching_patterns: &[&str],
+) -> Result<Vec<GenericCommandConfig>> {
+    let mut commands = Vec::new();
+    for pattern in matching_patterns {
+        if let Some(cmd_list) = config.commands.get(*pattern) {
+            for cmd_config in cmd_list {
+                for cmd in extract_bash_commands(&cmd_config.run)? {
+                    commands.push(GenericCommandConfig {
+                        command: cmd,
+                        message: cmd_config.message.clone(),
+                        show_stdout: cmd_config.show_stdout.unwrap_or(false),
+                        show_stderr: cmd_config.show_stderr.unwrap_or(false),
+                        max_output_lines: cmd_config.max_output_lines,
+                        timeout: cmd_config.timeout,
+                        show_command: cmd_config.show_command.unwrap_or(true),
+                        notify_per_command: cmd_config.notify_per_command.unwrap_or(false),
+                    });
+                }
+            }
+        }
+    }
+    Ok(commands)
+}
+
+/// Collect commands from `CwdChangedConfig` for matching patterns.
+fn collect_cwd_changed_commands(
+    config: &CwdChangedConfig,
+    matching_patterns: &[&str],
+) -> Result<Vec<GenericCommandConfig>> {
+    let mut commands = Vec::new();
+    for pattern in matching_patterns {
+        if let Some(cmd_list) = config.commands.get(*pattern) {
+            for cmd_config in cmd_list {
+                for cmd in extract_bash_commands(&cmd_config.run)? {
+                    commands.push(GenericCommandConfig {
+                        command: cmd,
+                        message: cmd_config.message.clone(),
+                        show_stdout: cmd_config.show_stdout.unwrap_or(false),
+                        show_stderr: cmd_config.show_stderr.unwrap_or(false),
+                        max_output_lines: cmd_config.max_output_lines,
+                        timeout: cmd_config.timeout,
+                        show_command: cmd_config.show_command.unwrap_or(true),
+                        notify_per_command: cmd_config.notify_per_command.unwrap_or(false),
+                    });
+                }
+            }
+        }
+    }
+    Ok(commands)
+}
+
+/// Collect commands from `FileChangedConfig` for matching patterns.
+fn collect_file_changed_commands(
+    config: &FileChangedConfig,
+    matching_patterns: &[&str],
+) -> Result<Vec<GenericCommandConfig>> {
+    let mut commands = Vec::new();
+    for pattern in matching_patterns {
+        if let Some(cmd_list) = config.commands.get(*pattern) {
+            for cmd_config in cmd_list {
+                for cmd in extract_bash_commands(&cmd_config.run)? {
+                    commands.push(GenericCommandConfig {
+                        command: cmd,
+                        message: cmd_config.message.clone(),
+                        show_stdout: cmd_config.show_stdout.unwrap_or(false),
+                        show_stderr: cmd_config.show_stderr.unwrap_or(false),
+                        max_output_lines: cmd_config.max_output_lines,
+                        timeout: cmd_config.timeout,
+                        show_command: cmd_config.show_command.unwrap_or(true),
+                        notify_per_command: cmd_config.notify_per_command.unwrap_or(false),
+                    });
+                }
+            }
+        }
+    }
+    Ok(commands)
+}
+
+/// Collect commands from `InstructionsLoadedConfig` for matching patterns.
+fn collect_instructions_loaded_commands(
+    config: &InstructionsLoadedConfig,
+    matching_patterns: &[&str],
+) -> Result<Vec<GenericCommandConfig>> {
+    let mut commands = Vec::new();
+    for pattern in matching_patterns {
+        if let Some(cmd_list) = config.commands.get(*pattern) {
+            for cmd_config in cmd_list {
+                for cmd in extract_bash_commands(&cmd_config.run)? {
+                    commands.push(GenericCommandConfig {
+                        command: cmd,
+                        message: cmd_config.message.clone(),
+                        show_stdout: cmd_config.show_stdout.unwrap_or(false),
+                        show_stderr: cmd_config.show_stderr.unwrap_or(false),
+                        max_output_lines: cmd_config.max_output_lines,
+                        timeout: cmd_config.timeout,
+                        show_command: cmd_config.show_command.unwrap_or(true),
+                        notify_per_command: cmd_config.notify_per_command.unwrap_or(false),
+                    });
+                }
+            }
+        }
+    }
+    Ok(commands)
+}
+
+/// Handles `PostCompact` hook events fired after transcript compaction completes.
+/// Observational - it cannot block.
+///
+/// # Errors
+///
+/// Returns an error if payload reading or validation fails.
+pub async fn handle_post_compact() -> Result<HookResult> {
+    let payload: PostCompactPayload = read_payload_from_stdin()?;
+    validate_post_compact_payload(&payload).map_err(|e| anyhow::anyhow!(e))?;
+
+    let trigger_str = payload.trigger.to_string();
+    println!(
+        "Processing PostCompact hook: session_id={}, trigger={}",
+        payload.base.session_id, trigger_str
+    );
+
+    let agent_name = std::env::var(AGENT_ENV_VAR).ok();
+    if let Some(ref name) = agent_name {
+        std::env::set_var("CONCLAUDE_AGENT_NAME", name);
+    }
+    std::env::set_var("CONCLAUDE_COMPACT_TRIGGER", &trigger_str);
+    std::env::set_var("CONCLAUDE_COMPACT_SUMMARY", &payload.compact_summary);
+
+    let (config, config_path) = get_config().await?;
+    let config_dir = get_config_dir(config_path);
+
+    if !config.post_compact.commands.is_empty() {
+        let matching_patterns =
+            match_generic_patterns(&trigger_str, &config.post_compact.commands)?;
+        if !matching_patterns.is_empty() {
+            let commands =
+                collect_post_compact_commands(&config.post_compact, &matching_patterns)?;
+            if !commands.is_empty() {
+                let mut env_vars = HashMap::new();
+                env_vars.insert("CONCLAUDE_COMPACT_TRIGGER".to_string(), trigger_str.clone());
+                env_vars.insert(
+                    "CONCLAUDE_COMPACT_SUMMARY".to_string(),
+                    payload.compact_summary.clone(),
+                );
+                insert_base_env_vars(
+                    &mut env_vars,
+                    &payload.base,
+                    &payload,
+                    "PostCompact",
+                    config_dir,
+                );
+                // Observational: run commands but never block.
+                let _ =
+                    execute_generic_commands(&commands, &env_vars, config_dir, "PostCompact").await;
+            }
+        }
+    }
+
+    send_notification(
+        "PostCompact",
+        "success",
+        Some(&format!("Compaction completed: trigger={trigger_str}")),
+    );
+    Ok(HookResult::success())
+}
+
+/// Handles `CwdChanged` hook events fired when the working directory changes.
+/// Observational - it cannot block.
+///
+/// # Errors
+///
+/// Returns an error if payload reading or validation fails.
+pub async fn handle_cwd_changed() -> Result<HookResult> {
+    let payload: CwdChangedPayload = read_payload_from_stdin()?;
+    validate_cwd_changed_payload(&payload).map_err(|e| anyhow::anyhow!(e))?;
+
+    println!(
+        "Processing CwdChanged hook: session_id={}, old_cwd={}, new_cwd={}",
+        payload.base.session_id, payload.old_cwd, payload.new_cwd
+    );
+
+    let agent_name = std::env::var(AGENT_ENV_VAR).ok();
+    if let Some(ref name) = agent_name {
+        std::env::set_var("CONCLAUDE_AGENT_NAME", name);
+    }
+    std::env::set_var("CONCLAUDE_OLD_CWD", &payload.old_cwd);
+    std::env::set_var("CONCLAUDE_NEW_CWD", &payload.new_cwd);
+
+    let (config, config_path) = get_config().await?;
+    let config_dir = get_config_dir(config_path);
+
+    if !config.cwd_changed.commands.is_empty() {
+        let matching_patterns =
+            match_generic_patterns(&payload.new_cwd, &config.cwd_changed.commands)?;
+        if !matching_patterns.is_empty() {
+            let commands = collect_cwd_changed_commands(&config.cwd_changed, &matching_patterns)?;
+            if !commands.is_empty() {
+                let mut env_vars = HashMap::new();
+                env_vars.insert("CONCLAUDE_OLD_CWD".to_string(), payload.old_cwd.clone());
+                env_vars.insert("CONCLAUDE_NEW_CWD".to_string(), payload.new_cwd.clone());
+                insert_base_env_vars(
+                    &mut env_vars,
+                    &payload.base,
+                    &payload,
+                    "CwdChanged",
+                    config_dir,
+                );
+                let _ =
+                    execute_generic_commands(&commands, &env_vars, config_dir, "CwdChanged").await;
+            }
+        }
+    }
+
+    send_notification(
+        "CwdChanged",
+        "success",
+        Some(&format!("Working directory changed to {}", payload.new_cwd)),
+    );
+    Ok(HookResult::success())
+}
+
+/// Handles `FileChanged` hook events fired when a watched file changes on disk.
+/// Observational - it cannot block.
+///
+/// # Errors
+///
+/// Returns an error if payload reading or validation fails.
+pub async fn handle_file_changed() -> Result<HookResult> {
+    let payload: FileChangedPayload = read_payload_from_stdin()?;
+    validate_file_changed_payload(&payload).map_err(|e| anyhow::anyhow!(e))?;
+
+    let event_str = payload.event.to_string();
+    println!(
+        "Processing FileChanged hook: session_id={}, file_path={}, event={}",
+        payload.base.session_id, payload.file_path, event_str
+    );
+
+    let agent_name = std::env::var(AGENT_ENV_VAR).ok();
+    if let Some(ref name) = agent_name {
+        std::env::set_var("CONCLAUDE_AGENT_NAME", name);
+    }
+    std::env::set_var("CONCLAUDE_FILE_PATH", &payload.file_path);
+    std::env::set_var("CONCLAUDE_FILE_EVENT", &event_str);
+
+    let (config, config_path) = get_config().await?;
+    let config_dir = get_config_dir(config_path);
+
+    if !config.file_changed.commands.is_empty() {
+        let matching_patterns =
+            match_generic_patterns(&payload.file_path, &config.file_changed.commands)?;
+        if !matching_patterns.is_empty() {
+            let commands = collect_file_changed_commands(&config.file_changed, &matching_patterns)?;
+            if !commands.is_empty() {
+                let mut env_vars = HashMap::new();
+                env_vars.insert("CONCLAUDE_FILE_PATH".to_string(), payload.file_path.clone());
+                env_vars.insert("CONCLAUDE_FILE_EVENT".to_string(), event_str.clone());
+                insert_base_env_vars(
+                    &mut env_vars,
+                    &payload.base,
+                    &payload,
+                    "FileChanged",
+                    config_dir,
+                );
+                let _ =
+                    execute_generic_commands(&commands, &env_vars, config_dir, "FileChanged").await;
+            }
+        }
+    }
+
+    send_notification(
+        "FileChanged",
+        "success",
+        Some(&format!("File {} ({})", payload.file_path, event_str)),
+    );
+    Ok(HookResult::success())
+}
+
+/// Handles `InstructionsLoaded` hook events fired when an instructions/memory file loads.
+/// Observational - it cannot block.
+///
+/// # Errors
+///
+/// Returns an error if payload reading or validation fails.
+pub async fn handle_instructions_loaded() -> Result<HookResult> {
+    let payload: InstructionsLoadedPayload = read_payload_from_stdin()?;
+    validate_instructions_loaded_payload(&payload).map_err(|e| anyhow::anyhow!(e))?;
+
+    let memory_type_str = payload.memory_type.to_string();
+    let load_reason_str = payload.load_reason.to_string();
+    println!(
+        "Processing InstructionsLoaded hook: session_id={}, file_path={}, memory_type={}, load_reason={}",
+        payload.base.session_id, payload.file_path, memory_type_str, load_reason_str
+    );
+
+    let agent_name = std::env::var(AGENT_ENV_VAR).ok();
+    if let Some(ref name) = agent_name {
+        std::env::set_var("CONCLAUDE_AGENT_NAME", name);
+    }
+    std::env::set_var("CONCLAUDE_INSTRUCTIONS_FILE_PATH", &payload.file_path);
+    std::env::set_var("CONCLAUDE_MEMORY_TYPE", &memory_type_str);
+    std::env::set_var("CONCLAUDE_LOAD_REASON", &load_reason_str);
+
+    let (config, config_path) = get_config().await?;
+    let config_dir = get_config_dir(config_path);
+
+    if !config.instructions_loaded.commands.is_empty() {
+        let matching_patterns =
+            match_generic_patterns(&memory_type_str, &config.instructions_loaded.commands)?;
+        if !matching_patterns.is_empty() {
+            let commands = collect_instructions_loaded_commands(
+                &config.instructions_loaded,
+                &matching_patterns,
+            )?;
+            if !commands.is_empty() {
+                let mut env_vars = HashMap::new();
+                env_vars.insert(
+                    "CONCLAUDE_INSTRUCTIONS_FILE_PATH".to_string(),
+                    payload.file_path.clone(),
+                );
+                env_vars.insert("CONCLAUDE_MEMORY_TYPE".to_string(), memory_type_str.clone());
+                env_vars.insert("CONCLAUDE_LOAD_REASON".to_string(), load_reason_str.clone());
+                insert_base_env_vars(
+                    &mut env_vars,
+                    &payload.base,
+                    &payload,
+                    "InstructionsLoaded",
+                    config_dir,
+                );
+                let _ = execute_generic_commands(
+                    &commands,
+                    &env_vars,
+                    config_dir,
+                    "InstructionsLoaded",
+                )
+                .await;
+            }
+        }
+    }
+
+    send_notification(
+        "InstructionsLoaded",
+        "success",
+        Some(&format!(
+            "Instructions loaded: {} ({memory_type_str})",
+            payload.file_path
+        )),
+    );
+    Ok(HookResult::success())
 }
 
 /// Handles `WorktreeCreate` hook events when a git worktree needs to be created.

--- a/src/hooks_tests.rs
+++ b/src/hooks_tests.rs
@@ -29,6 +29,10 @@ fn test_is_system_event_hook_new_hooks() {
     assert!(is_system_event_hook("ConfigChange"));
     assert!(is_system_event_hook("WorktreeCreate"));
     assert!(is_system_event_hook("WorktreeRemove"));
+    assert!(is_system_event_hook("PostCompact"));
+    assert!(is_system_event_hook("CwdChanged"));
+    assert!(is_system_event_hook("FileChanged"));
+    assert!(is_system_event_hook("InstructionsLoaded"));
 
     // PostToolUseFailure is NOT a system event hook
     assert!(!is_system_event_hook("PostToolUseFailure"));

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,11 +8,13 @@ mod types;
 use anyhow::{Context, Result};
 use clap::{Parser, Subcommand};
 use hooks::{
-    handle_config_change, handle_hook_result, handle_notification, handle_permission_request,
-    handle_post_tool_use, handle_post_tool_use_failure, handle_pre_compact, handle_pre_tool_use,
-    handle_session_end, handle_session_start, handle_setup, handle_stop, handle_stop_failure,
-    handle_subagent_start, handle_subagent_stop, handle_task_completed, handle_teammate_idle,
-    handle_user_prompt_submit, handle_worktree_create_result, handle_worktree_remove,
+    handle_config_change, handle_cwd_changed, handle_file_changed, handle_hook_result,
+    handle_instructions_loaded, handle_notification, handle_permission_request,
+    handle_post_compact, handle_post_tool_use, handle_post_tool_use_failure, handle_pre_compact,
+    handle_pre_tool_use, handle_session_end, handle_session_start, handle_setup, handle_stop,
+    handle_stop_failure, handle_subagent_start, handle_subagent_stop, handle_task_completed,
+    handle_teammate_idle, handle_user_prompt_submit, handle_worktree_create_result,
+    handle_worktree_remove,
 };
 use std::fs;
 use std::path::{Path, PathBuf};
@@ -221,6 +223,34 @@ enum HooksCommands {
         #[clap(long)]
         agent: Option<String>,
     },
+    /// Process `PostCompact` hook - fired after transcript compaction completes
+    #[clap(name = "PostCompact")]
+    PostCompact {
+        /// Optional agent name for context-aware hook execution
+        #[clap(long)]
+        agent: Option<String>,
+    },
+    /// Process `CwdChanged` hook - fired when the working directory changes
+    #[clap(name = "CwdChanged")]
+    CwdChanged {
+        /// Optional agent name for context-aware hook execution
+        #[clap(long)]
+        agent: Option<String>,
+    },
+    /// Process `FileChanged` hook - fired when a watched file changes on disk
+    #[clap(name = "FileChanged")]
+    FileChanged {
+        /// Optional agent name for context-aware hook execution
+        #[clap(long)]
+        agent: Option<String>,
+    },
+    /// Process `InstructionsLoaded` hook - fired when an instructions/memory file loads
+    #[clap(name = "InstructionsLoaded")]
+    InstructionsLoaded {
+        /// Optional agent name for context-aware hook execution
+        #[clap(long)]
+        agent: Option<String>,
+    },
 }
 
 #[tokio::main]
@@ -310,6 +340,22 @@ async fn main() -> Result<()> {
             HooksCommands::Setup { agent } => {
                 set_agent_env(agent.as_deref());
                 handle_hook_result(handle_setup).await
+            }
+            HooksCommands::PostCompact { agent } => {
+                set_agent_env(agent.as_deref());
+                handle_hook_result(handle_post_compact).await
+            }
+            HooksCommands::CwdChanged { agent } => {
+                set_agent_env(agent.as_deref());
+                handle_hook_result(handle_cwd_changed).await
+            }
+            HooksCommands::FileChanged { agent } => {
+                set_agent_env(agent.as_deref());
+                handle_hook_result(handle_file_changed).await
+            }
+            HooksCommands::InstructionsLoaded { agent } => {
+                set_agent_env(agent.as_deref());
+                handle_hook_result(handle_instructions_loaded).await
             }
         },
         Commands::Visualize { rule, show_matches } => handle_visualize(rule, show_matches).await,
@@ -500,6 +546,10 @@ async fn handle_init(
         "WorktreeCreate",
         "WorktreeRemove",
         "Setup",
+        "PostCompact",
+        "CwdChanged",
+        "FileChanged",
+        "InstructionsLoaded",
     ];
 
     // Add hook configurations using merge logic to preserve user-defined hooks
@@ -644,6 +694,10 @@ fn generate_agent_hooks(agent_name: &str) -> serde_yaml::Value {
         ("WorktreeCreate", false),
         ("WorktreeRemove", false),
         ("Setup", true), // needs matcher (trigger)
+        ("PostCompact", true), // needs matcher (trigger)
+        ("CwdChanged", false),
+        ("FileChanged", true), // needs matcher (file_path)
+        ("InstructionsLoaded", true), // needs matcher (memory_type)
     ];
 
     let mut hooks_map = Mapping::new();

--- a/src/types.rs
+++ b/src/types.rs
@@ -332,11 +332,20 @@ pub struct PreCompactPayload {
     pub custom_instructions: Option<String>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(rename_all = "lowercase")]
 pub enum CompactTrigger {
     Manual,
     Auto,
+}
+
+impl std::fmt::Display for CompactTrigger {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            CompactTrigger::Manual => write!(f, "manual"),
+            CompactTrigger::Auto => write!(f, "auto"),
+        }
+    }
 }
 
 /// Payload for `SessionStart` hook - fired when a new Claude session begins.
@@ -627,6 +636,165 @@ pub fn validate_worktree_remove_payload(payload: &WorktreeRemovePayload) -> Resu
     validate_base_payload(&payload.base)?;
     if payload.worktree_path.trim().is_empty() {
         return Err("worktree_path cannot be empty".to_string());
+    }
+    Ok(())
+}
+
+/// Payload for `PostCompact` hook - fired after transcript compaction completes.
+/// Observational; exposes the produced conversation summary.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PostCompactPayload {
+    #[serde(flatten)]
+    pub base: BasePayload,
+    /// Whether compaction was triggered manually by user or automatically by system
+    pub trigger: CompactTrigger,
+    /// The conversation summary produced by compaction
+    pub compact_summary: String,
+}
+
+/// Payload for `CwdChanged` hook - fired when the working directory changes.
+/// Observational; allows reacting to directory switches (e.g. re-priming watches).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CwdChangedPayload {
+    #[serde(flatten)]
+    pub base: BasePayload,
+    /// The previous working directory
+    pub old_cwd: String,
+    /// The new working directory
+    pub new_cwd: String,
+}
+
+/// Filesystem event type reported by the `FileChanged` hook.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "lowercase")]
+pub enum FileChangeEvent {
+    /// An existing file was modified
+    Change,
+    /// A new file was created
+    Add,
+    /// A file was removed
+    Unlink,
+}
+
+impl std::fmt::Display for FileChangeEvent {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            FileChangeEvent::Change => write!(f, "change"),
+            FileChangeEvent::Add => write!(f, "add"),
+            FileChangeEvent::Unlink => write!(f, "unlink"),
+        }
+    }
+}
+
+/// Payload for `FileChanged` hook - fired when a watched file changes on disk.
+/// Observational; allows reacting to external file modifications.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct FileChangedPayload {
+    #[serde(flatten)]
+    pub base: BasePayload,
+    /// Path to the file that changed
+    pub file_path: String,
+    /// The kind of filesystem event that occurred
+    pub event: FileChangeEvent,
+}
+
+/// Source tier of an instructions/memory file loaded by Claude Code.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub enum MemoryType {
+    User,
+    Project,
+    Local,
+    Managed,
+}
+
+impl std::fmt::Display for MemoryType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            MemoryType::User => write!(f, "User"),
+            MemoryType::Project => write!(f, "Project"),
+            MemoryType::Local => write!(f, "Local"),
+            MemoryType::Managed => write!(f, "Managed"),
+        }
+    }
+}
+
+/// Reason an instructions/memory file was loaded.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "snake_case")]
+pub enum LoadReason {
+    SessionStart,
+    NestedTraversal,
+    PathGlobMatch,
+    Include,
+    Compact,
+}
+
+impl std::fmt::Display for LoadReason {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            LoadReason::SessionStart => write!(f, "session_start"),
+            LoadReason::NestedTraversal => write!(f, "nested_traversal"),
+            LoadReason::PathGlobMatch => write!(f, "path_glob_match"),
+            LoadReason::Include => write!(f, "include"),
+            LoadReason::Compact => write!(f, "compact"),
+        }
+    }
+}
+
+/// Payload for `InstructionsLoaded` hook - fired when Claude Code loads an
+/// instructions/memory file (e.g. CLAUDE.md). Observational.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct InstructionsLoadedPayload {
+    #[serde(flatten)]
+    pub base: BasePayload,
+    /// Path to the instructions file that was loaded
+    pub file_path: String,
+    /// Source tier of the loaded file
+    pub memory_type: MemoryType,
+    /// Why the file was loaded
+    pub load_reason: LoadReason,
+    /// Glob patterns that triggered a path-glob-match load, when applicable
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub globs: Option<Vec<String>>,
+    /// Path of the file whose access triggered the load, when applicable
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub trigger_file_path: Option<String>,
+    /// Path of the parent file that included this one, when applicable
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub parent_file_path: Option<String>,
+}
+
+/// Validates that a `PostCompactPayload` contains all required fields.
+pub fn validate_post_compact_payload(payload: &PostCompactPayload) -> Result<(), String> {
+    validate_base_payload(&payload.base)?;
+    Ok(())
+}
+
+/// Validates that a `CwdChangedPayload` contains all required fields.
+pub fn validate_cwd_changed_payload(payload: &CwdChangedPayload) -> Result<(), String> {
+    validate_base_payload(&payload.base)?;
+    if payload.new_cwd.trim().is_empty() {
+        return Err("new_cwd cannot be empty".to_string());
+    }
+    Ok(())
+}
+
+/// Validates that a `FileChangedPayload` contains all required fields.
+pub fn validate_file_changed_payload(payload: &FileChangedPayload) -> Result<(), String> {
+    validate_base_payload(&payload.base)?;
+    if payload.file_path.trim().is_empty() {
+        return Err("file_path cannot be empty".to_string());
+    }
+    Ok(())
+}
+
+/// Validates that an `InstructionsLoadedPayload` contains all required fields.
+pub fn validate_instructions_loaded_payload(
+    payload: &InstructionsLoadedPayload,
+) -> Result<(), String> {
+    validate_base_payload(&payload.base)?;
+    if payload.file_path.trim().is_empty() {
+        return Err("file_path cannot be empty".to_string());
     }
     Ok(())
 }
@@ -1430,5 +1598,117 @@ mod tests {
             ..payload.clone()
         };
         assert!(validate_stop_failure_payload(&empty_error).is_err());
+    }
+
+    #[test]
+    fn test_post_compact_payload_deserialization() {
+        let json = r#"{
+            "session_id": "s",
+            "transcript_path": "/t",
+            "hook_event_name": "PostCompact",
+            "cwd": "/c",
+            "trigger": "auto",
+            "compact_summary": "Summarized the conversation."
+        }"#;
+        let payload: PostCompactPayload = serde_json::from_str(json).unwrap();
+        assert_eq!(payload.trigger, CompactTrigger::Auto);
+        assert_eq!(payload.compact_summary, "Summarized the conversation.");
+        assert!(validate_post_compact_payload(&payload).is_ok());
+    }
+
+    #[test]
+    fn test_cwd_changed_payload_deserialization() {
+        let json = r#"{
+            "session_id": "s",
+            "transcript_path": "/t",
+            "hook_event_name": "CwdChanged",
+            "cwd": "/c",
+            "old_cwd": "/home/a",
+            "new_cwd": "/home/b"
+        }"#;
+        let payload: CwdChangedPayload = serde_json::from_str(json).unwrap();
+        assert_eq!(payload.old_cwd, "/home/a");
+        assert_eq!(payload.new_cwd, "/home/b");
+        assert!(validate_cwd_changed_payload(&payload).is_ok());
+    }
+
+    #[test]
+    fn test_cwd_changed_payload_validation_empty_new_cwd() {
+        let json = r#"{
+            "session_id": "s",
+            "transcript_path": "/t",
+            "hook_event_name": "CwdChanged",
+            "cwd": "/c",
+            "old_cwd": "/home/a",
+            "new_cwd": ""
+        }"#;
+        let payload: CwdChangedPayload = serde_json::from_str(json).unwrap();
+        assert!(validate_cwd_changed_payload(&payload).is_err());
+    }
+
+    #[test]
+    fn test_file_changed_payload_deserialization() {
+        for (raw, expected) in [
+            ("change", FileChangeEvent::Change),
+            ("add", FileChangeEvent::Add),
+            ("unlink", FileChangeEvent::Unlink),
+        ] {
+            let json = format!(
+                r#"{{
+                    "session_id": "s",
+                    "transcript_path": "/t",
+                    "hook_event_name": "FileChanged",
+                    "cwd": "/c",
+                    "file_path": "src/main.rs",
+                    "event": "{raw}"
+                }}"#
+            );
+            let payload: FileChangedPayload = serde_json::from_str(&json).unwrap();
+            assert_eq!(payload.event, expected);
+            assert_eq!(payload.event.to_string(), raw);
+            assert!(validate_file_changed_payload(&payload).is_ok());
+        }
+    }
+
+    #[test]
+    fn test_instructions_loaded_payload_deserialization() {
+        let json = r#"{
+            "session_id": "s",
+            "transcript_path": "/t",
+            "hook_event_name": "InstructionsLoaded",
+            "cwd": "/c",
+            "file_path": "/home/user/CLAUDE.md",
+            "memory_type": "User",
+            "load_reason": "session_start"
+        }"#;
+        let payload: InstructionsLoadedPayload = serde_json::from_str(json).unwrap();
+        assert_eq!(payload.memory_type, MemoryType::User);
+        assert_eq!(payload.load_reason, LoadReason::SessionStart);
+        assert_eq!(payload.memory_type.to_string(), "User");
+        assert_eq!(payload.load_reason.to_string(), "session_start");
+        assert_eq!(payload.globs, None);
+        assert!(validate_instructions_loaded_payload(&payload).is_ok());
+    }
+
+    #[test]
+    fn test_instructions_loaded_payload_with_optional_fields() {
+        let json = r#"{
+            "session_id": "s",
+            "transcript_path": "/t",
+            "hook_event_name": "InstructionsLoaded",
+            "cwd": "/c",
+            "file_path": "/repo/sub/CLAUDE.md",
+            "memory_type": "Project",
+            "load_reason": "path_glob_match",
+            "globs": ["**/*.rs"],
+            "trigger_file_path": "/repo/sub/lib.rs",
+            "parent_file_path": "/repo/CLAUDE.md"
+        }"#;
+        let payload: InstructionsLoadedPayload = serde_json::from_str(json).unwrap();
+        assert_eq!(payload.memory_type, MemoryType::Project);
+        assert_eq!(payload.load_reason, LoadReason::PathGlobMatch);
+        assert_eq!(payload.globs, Some(vec!["**/*.rs".to_string()]));
+        assert_eq!(payload.trigger_file_path, Some("/repo/sub/lib.rs".to_string()));
+        assert_eq!(payload.parent_file_path, Some("/repo/CLAUDE.md".to_string()));
     }
 }


### PR DESCRIPTION
## Summary
Second in the sequential series adding support for new Claude Code hook events from `@anthropic-ai/claude-agent-sdk`. Adds **four observational lifecycle hooks**, each with pattern-based command configuration following the established `setup`/`teammateIdle` pattern.

| Hook | Match key | Env vars exposed |
|------|-----------|------------------|
| `PostCompact` | trigger (`manual`/`auto`) | `CONCLAUDE_COMPACT_TRIGGER`, `CONCLAUDE_COMPACT_SUMMARY` |
| `CwdChanged` | new_cwd (glob) | `CONCLAUDE_OLD_CWD`, `CONCLAUDE_NEW_CWD` |
| `FileChanged` | file_path (glob) | `CONCLAUDE_FILE_PATH`, `CONCLAUDE_FILE_EVENT` |
| `InstructionsLoaded` | memory_type (glob) | `CONCLAUDE_INSTRUCTIONS_FILE_PATH`, `CONCLAUDE_MEMORY_TYPE`, `CONCLAUDE_LOAD_REASON` |

All four are **observational** (commands run but cannot block, matching SDK semantics). Includes payload + config types, handlers, CLI subcommands, `init`/agent-hook wiring, registration in `is_system_event_hook` (so per-command notifications classify correctly), a `Display` impl for `CompactTrigger`, regenerated schema + docs, and deserialization/validation tests.

This PR was reviewed by an adversarial multi-agent workflow against the SDK type definitions; SDK field/enum fidelity verified clean, and the `is_system_event_hook` registration gap it surfaced is fixed here.

## Testing
- `cargo clippy --all-targets --all-features` — clean
- `cargo test` — all pass
- `spectr validate --all` — green; docs build — green

🤖 Generated with [Claude Code](https://claude.com/claude-code)