### PR TITLE
feat: add PostToolBatch, PermissionDenied, UserPromptExpansion hooks

### DIFF
--- a/conclaude-schema.json
+++ b/conclaude-schema.json
@@ -449,6 +449,100 @@
       },
       "type": "object"
     },
+    "PermissionDeniedCommand": {
+      "additionalProperties": false,
+      "description": "Configuration for individual permission-denied commands with optional messages.",
+      "properties": {
+        "maxOutputLines": {
+          "default": null,
+          "description": "Maximum number of output lines to display (limits both stdout and stderr). Range: 1-10000",
+          "format": "uint32",
+          "maximum": 10000.0,
+          "minimum": 1.0,
+          "type": [
+            "integer",
+            "null"
+          ]
+        },
+        "message": {
+          "default": null,
+          "description": "Custom error message to display when the command fails (exits with non-zero status)",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "notifyPerCommand": {
+          "default": null,
+          "description": "Whether to send individual notifications for this command. Default: false",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "run": {
+          "description": "The shell command to execute. Environment variables are available: CONCLAUDE_TOOL_NAME, CONCLAUDE_DENY_REASON, CONCLAUDE_TOOL_USE_ID, CONCLAUDE_SESSION_ID, CONCLAUDE_TRANSCRIPT_PATH, CONCLAUDE_HOOK_EVENT, CONCLAUDE_CWD, CONCLAUDE_CONFIG_DIR, CONCLAUDE_PAYLOAD_JSON",
+          "type": "string"
+        },
+        "showCommand": {
+          "default": true,
+          "description": "Whether to show the command being executed to the user and Claude. Default: true",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "showStderr": {
+          "default": null,
+          "description": "Whether to show the command's standard error output to the user and Claude. Default: false",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "showStdout": {
+          "default": null,
+          "description": "Whether to show the command's standard output to the user and Claude. Default: false",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "timeout": {
+          "default": null,
+          "description": "Optional command timeout in seconds. Range: 1-3600 (1 second to 1 hour).",
+          "format": "uint64",
+          "maximum": 3600.0,
+          "minimum": 1.0,
+          "type": [
+            "integer",
+            "null"
+          ]
+        }
+      },
+      "required": [
+        "run"
+      ],
+      "type": "object"
+    },
+    "PermissionDeniedConfig": {
+      "additionalProperties": false,
+      "description": "Configuration for permission-denied hooks with tool-based command execution.\n\nCommands run when a tool permission request is denied. Observational.",
+      "properties": {
+        "commands": {
+          "additionalProperties": {
+            "items": {
+              "$ref": "#/definitions/PermissionDeniedCommand"
+            },
+            "type": "array"
+          },
+          "default": {},
+          "description": "Map of tool-name patterns to command configurations. Keys are glob patterns matched against the denied tool name (e.g., \"Bash\", \"*\").",
+          "type": "object"
+        }
+      },
+      "type": "object"
+    },
     "PermissionRequestConfig": {
       "additionalProperties": false,
       "description": "Configuration for permission request hooks that control tool permission decisions.\n\nThis hook is fired when Claude requests permission to use a tool. Use this to automatically approve or deny tool usage based on configurable rules.\n\n# Pattern Matching\n\nBoth `allow` and `deny` fields support glob patterns for flexible tool matching: - `\"Bash\"` - Exact match (only \"Bash\") - `\"*\"` - Wildcard (matches any tool) - `\"Edit*\"` - Prefix match (matches \"Edit\", \"EditFile\", etc.) - `\"*Read\"` - Suffix match (matches \"Read\", \"FileRead\", etc.)\n\n**Important**: Deny patterns take precedence over allow patterns.\n\n# Security Recommendations\n\n- **Whitelist approach (recommended)**: Set `default: \"deny\"` and explicitly list allowed tools - **Blacklist approach (more permissive)**: Set `default: \"allow\"` and explicitly list denied tools\n\n# Examples\n\n## Whitelist approach (recommended for security)\n\n```yaml permissionRequest: default: deny allow: - \"Read\"       # Allow reading files - \"Glob\"       # Allow file pattern matching - \"Grep\"       # Allow content search - \"Edit\"       # Allow file editing - \"Write\"      # Allow file writing - \"Task\"       # Allow subagent tasks - \"Bash\"       # Allow bash commands ```\n\n## Blacklist approach (more permissive)\n\n```yaml permissionRequest: default: allow deny: - \"BashOutput\"   # Block reading background process output - \"KillShell\"    # Block terminating background shells ```\n\n## Mixed approach with patterns\n\n```yaml permissionRequest: default: deny allow: - \"Read\" - \"Write\" - \"Edit*\"      # Allow all Edit-based tools deny: - \"Bash\"       # Explicitly deny even though default is deny ```",
@@ -575,6 +669,97 @@
           "default": {},
           "description": "Map of trigger patterns to command configurations. Keys are glob patterns matching the compaction trigger (e.g., \"manual\", \"auto\", \"*\").",
           "type": "object"
+        }
+      },
+      "type": "object"
+    },
+    "PostToolBatchCommand": {
+      "additionalProperties": false,
+      "description": "Configuration for individual post-tool-batch commands with optional messages.",
+      "properties": {
+        "maxOutputLines": {
+          "default": null,
+          "description": "Maximum number of output lines to display (limits both stdout and stderr). Range: 1-10000",
+          "format": "uint32",
+          "maximum": 10000.0,
+          "minimum": 1.0,
+          "type": [
+            "integer",
+            "null"
+          ]
+        },
+        "message": {
+          "default": null,
+          "description": "Custom error message to display when the command fails (exits with non-zero status)",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "notifyPerCommand": {
+          "default": null,
+          "description": "Whether to send individual notifications for this command. Default: false",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "run": {
+          "description": "The shell command to execute. Environment variables are available: CONCLAUDE_TOOL_BATCH_SIZE, CONCLAUDE_TOOL_BATCH_NAMES, CONCLAUDE_SESSION_ID, CONCLAUDE_TRANSCRIPT_PATH, CONCLAUDE_HOOK_EVENT, CONCLAUDE_CWD, CONCLAUDE_CONFIG_DIR, CONCLAUDE_PAYLOAD_JSON",
+          "type": "string"
+        },
+        "showCommand": {
+          "default": true,
+          "description": "Whether to show the command being executed to the user and Claude. Default: true",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "showStderr": {
+          "default": null,
+          "description": "Whether to show the command's standard error output to the user and Claude. Default: false",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "showStdout": {
+          "default": null,
+          "description": "Whether to show the command's standard output to the user and Claude. Default: false",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "timeout": {
+          "default": null,
+          "description": "Optional command timeout in seconds. Range: 1-3600 (1 second to 1 hour).",
+          "format": "uint64",
+          "maximum": 3600.0,
+          "minimum": 1.0,
+          "type": [
+            "integer",
+            "null"
+          ]
+        }
+      },
+      "required": [
+        "run"
+      ],
+      "type": "object"
+    },
+    "PostToolBatchConfig": {
+      "additionalProperties": false,
+      "description": "Configuration for post-tool-batch hooks.\n\nCommands run once after every tool call in a batch resolves. Observational.",
+      "properties": {
+        "commands": {
+          "default": [],
+          "description": "Commands to execute after each resolved tool batch. They run in order and are observational.",
+          "items": {
+            "$ref": "#/definitions/PostToolBatchCommand"
+          },
+          "type": "array"
         }
       },
       "type": "object"
@@ -1402,6 +1587,100 @@
       ],
       "description": "Configuration for an uneditable file rule.\n\nFiles that Claude cannot edit, using glob patterns. Supports various glob patterns for flexible file protection.\n\n# Formats\n\nTwo formats are supported for backward compatibility:\n\n1. **Simple string patterns**: `\"*.lock\"` - Just the glob pattern as a string - Uses a generic error message when blocking\n\n2. **Detailed objects with custom messages**: `{pattern: \"*.lock\", message: \"...\"}` - Allows specifying a custom error message - More descriptive feedback when files are blocked\n\n# Examples\n\n```yaml uneditableFiles: # Simple patterns (backward compatible) - \"./package.json\"      # specific file - \"*.md\"                # file extension - \"src/**/*.ts\"         # nested patterns - \"docs/**\"             # entire directories\n\n# Detailed patterns with custom error messages - pattern: \"*.lock\" message: \"Lock files are automatically created. Run 'npm install' to update.\" - pattern: \".env*\" message: \"Environment files contain secrets. Use .env.example instead.\" - pattern: \"{package,tsconfig}.json\" message: \"Configuration files require team review before changes.\"\n\n# Agent-scoped patterns (only applied to specific agents) - pattern: \"src/**/*.test.ts\" agent: \"coder\" message: \"The coder agent should not modify test files.\" - pattern: \"dist/**\" agent: \"test*\" message: \"Test agents should not modify build output.\" ```\n\nThe `#[serde(untagged)]` attribute allows serde to automatically handle both plain string patterns and detailed object configurations."
     },
+    "UserPromptExpansionCommand": {
+      "additionalProperties": false,
+      "description": "Configuration for individual user-prompt-expansion commands with optional messages.",
+      "properties": {
+        "maxOutputLines": {
+          "default": null,
+          "description": "Maximum number of output lines to display (limits both stdout and stderr). Range: 1-10000",
+          "format": "uint32",
+          "maximum": 10000.0,
+          "minimum": 1.0,
+          "type": [
+            "integer",
+            "null"
+          ]
+        },
+        "message": {
+          "default": null,
+          "description": "Custom error message to display when the command fails (exits with non-zero status)",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "notifyPerCommand": {
+          "default": null,
+          "description": "Whether to send individual notifications for this command. Default: false",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "run": {
+          "description": "The shell command to execute. Environment variables are available: CONCLAUDE_EXPANSION_TYPE, CONCLAUDE_COMMAND_NAME, CONCLAUDE_COMMAND_ARGS, CONCLAUDE_COMMAND_SOURCE, CONCLAUDE_EXPANDED_PROMPT, CONCLAUDE_SESSION_ID, CONCLAUDE_TRANSCRIPT_PATH, CONCLAUDE_HOOK_EVENT, CONCLAUDE_CWD, CONCLAUDE_CONFIG_DIR, CONCLAUDE_PAYLOAD_JSON",
+          "type": "string"
+        },
+        "showCommand": {
+          "default": true,
+          "description": "Whether to show the command being executed to the user and Claude. Default: true",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "showStderr": {
+          "default": null,
+          "description": "Whether to show the command's standard error output to the user and Claude. Default: false",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "showStdout": {
+          "default": null,
+          "description": "Whether to show the command's standard output to the user and Claude. Default: false",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "timeout": {
+          "default": null,
+          "description": "Optional command timeout in seconds. Range: 1-3600 (1 second to 1 hour).",
+          "format": "uint64",
+          "maximum": 3600.0,
+          "minimum": 1.0,
+          "type": [
+            "integer",
+            "null"
+          ]
+        }
+      },
+      "required": [
+        "run"
+      ],
+      "type": "object"
+    },
+    "UserPromptExpansionConfig": {
+      "additionalProperties": false,
+      "description": "Configuration for user-prompt-expansion hooks with command-name-based command execution.\n\nCommands run when a slash command or MCP prompt is expanded. Observational.",
+      "properties": {
+        "commands": {
+          "additionalProperties": {
+            "items": {
+              "$ref": "#/definitions/UserPromptExpansionCommand"
+            },
+            "type": "array"
+          },
+          "default": {},
+          "description": "Map of command-name patterns to command configurations. Keys are glob patterns matched against the expanded command name (e.g., \"commit\", \"*\").",
+          "type": "object"
+        }
+      },
+      "type": "object"
+    },
     "UserPromptSubmitCommand": {
       "additionalProperties": false,
       "description": "Configuration for individual user prompt submit commands.\n\nThese commands run when a user submits a prompt to Claude. Commands are observational (read-only) and cannot block prompt processing.\n\n# Environment Variables\n\nThe following environment variables are available in commands: - `CONCLAUDE_USER_PROMPT` - The user's input text - `CONCLAUDE_SESSION_ID` - Current session ID - `CONCLAUDE_CWD` - Current working directory - `CONCLAUDE_CONFIG_DIR` - Directory containing .conclaude.yaml - `CONCLAUDE_HOOK_EVENT` - Always \"UserPromptSubmit\"\n\n# Examples\n\n```yaml userPromptSubmit: commands: # Run for all prompts - run: \".claude/scripts/log-prompt.sh\"\n\n# Run only for prompts matching pattern (regex) - pattern: \"deploy|release\" run: \".claude/scripts/notify-deploy.sh\"\n\n# Run with output display options - pattern: \"test\" run: \".claude/scripts/pre-test-check.sh\" showStdout: true ```",
@@ -1608,6 +1887,17 @@
         "showSystemEvents": false
       }
     },
+    "permissionDenied": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/PermissionDeniedConfig"
+        }
+      ],
+      "default": {
+        "commands": {}
+      },
+      "description": "Configuration for permission-denied hooks that run when a tool permission is denied."
+    },
     "permissionRequest": {
       "anyOf": [
         {
@@ -1629,6 +1919,17 @@
         "commands": {}
       },
       "description": "Configuration for post-compact hooks that run after transcript compaction."
+    },
+    "postToolBatch": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/PostToolBatchConfig"
+        }
+      ],
+      "default": {
+        "commands": []
+      },
+      "description": "Configuration for post-tool-batch hooks that run after each resolved tool batch."
     },
     "preToolUse": {
       "allOf": [
@@ -1721,6 +2022,17 @@
         "commands": {}
       },
       "description": "Configuration for teammate idle hooks"
+    },
+    "userPromptExpansion": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/UserPromptExpansionConfig"
+        }
+      ],
+      "default": {
+        "commands": {}
+      },
+      "description": "Configuration for user-prompt-expansion hooks that run when a command/prompt expands."
     },
     "userPromptSubmit": {
       "allOf": [

--- a/docs/src/content/docs/reference/config/configuration.md
+++ b/docs/src/content/docs/reference/config/configuration.md
@@ -18,8 +18,10 @@ Conclaude uses YAML configuration files to define lifecycle hooks, file protecti
 | [File Changed](/conclaude/reference/config/file-changed) | Configuration for file-changed hooks with path-based command execution | `commands` |
 | [Instructions Loaded](/conclaude/reference/config/instructions-loaded) | Configuration for instructions-loaded hooks with command execution | `commands` |
 | [Notifications](/conclaude/reference/config/notifications) | Configuration for system notifications | `enabled`, `hooks`, `showErrors` |
+| [Permission Denied](/conclaude/reference/config/permission-denied) | Configuration for permission-denied hooks with tool-based command execution | `commands` |
 | [Permission Request](/conclaude/reference/config/permission-request) | Configuration for permission request hooks that control tool permission decisions | `allow`, `default`, `deny` |
 | [Post Compact](/conclaude/reference/config/post-compact) | Configuration for post-compact hooks with trigger-based command execution | `commands` |
+| [Post Tool Batch](/conclaude/reference/config/post-tool-batch) | Configuration for post-tool-batch hooks | `commands` |
 | [Pre Tool Use](/conclaude/reference/config/pre-tool-use) | Configuration for pre-tool-use hooks that run before tools are executed | `preventAdditions`, `preventRootAdditions`, `preventRootAdditionsMessage` |
 | [Setup](/conclaude/reference/config/setup) | Configuration for setup hooks with trigger-based command execution | `commands` |
 | [Skill Start](/conclaude/reference/config/skill-start) | Configuration for skill start hooks that trigger when subagents (skills) start | `commands` |
@@ -28,6 +30,7 @@ Conclaude uses YAML configuration files to define lifecycle hooks, file protecti
 | [Subagent Stop](/conclaude/reference/config/subagent-stop) | Configuration for subagent stop hooks with pattern-based command execution | `commands` |
 | [Task Completed](/conclaude/reference/config/task-completed) | Configuration for task completed hooks with pattern-based command execution | `commands` |
 | [Teammate Idle](/conclaude/reference/config/teammate-idle) | Configuration for teammate idle hooks with pattern-based command execution | `commands` |
+| [User Prompt Expansion](/conclaude/reference/config/user-prompt-expansion) | Configuration for user-prompt-expansion hooks with command-name-based command execution | `commands` |
 | [User Prompt Submit](/conclaude/reference/config/user-prompt-submit) | Configuration for user prompt submit hook with context injection rules and command execution | `commands`, `contextRules`, `slashCommands` |
 | [Worktree Create](/conclaude/reference/config/worktree-create) | Configuration for worktree create hook | `command`, `timeout` |
 
@@ -55,6 +58,10 @@ Configuration for instructions-loaded hooks with command execution.
 
 Configuration for system notifications.
 
+### [Permission Denied](/conclaude/reference/config/permission-denied)
+
+Configuration for permission-denied hooks with tool-based command execution.
+
 ### [Permission Request](/conclaude/reference/config/permission-request)
 
 Configuration for permission request hooks that control tool permission decisions.
@@ -62,6 +69,10 @@ Configuration for permission request hooks that control tool permission decision
 ### [Post Compact](/conclaude/reference/config/post-compact)
 
 Configuration for post-compact hooks with trigger-based command execution.
+
+### [Post Tool Batch](/conclaude/reference/config/post-tool-batch)
+
+Configuration for post-tool-batch hooks.
 
 ### [Pre Tool Use](/conclaude/reference/config/pre-tool-use)
 
@@ -94,6 +105,10 @@ Configuration for task completed hooks with pattern-based command execution.
 ### [Teammate Idle](/conclaude/reference/config/teammate-idle)
 
 Configuration for teammate idle hooks with pattern-based command execution.
+
+### [User Prompt Expansion](/conclaude/reference/config/user-prompt-expansion)
+
+Configuration for user-prompt-expansion hooks with command-name-based command execution.
 
 ### [User Prompt Submit](/conclaude/reference/config/user-prompt-submit)
 

--- a/docs/src/content/docs/reference/config/permission-denied.md
+++ b/docs/src/content/docs/reference/config/permission-denied.md
@@ -1,0 +1,46 @@
+---
+title: Permission Denied
+description: Configuration options for permissionDenied
+---
+
+# Permission Denied
+
+Configuration for permission-denied hooks with tool-based command execution.
+
+Commands run when a tool permission request is denied. Observational.
+
+## Configuration Properties
+
+### `commands`
+
+Map of tool-name patterns to command configurations. Keys are glob patterns matched against the denied tool name (e.g., "Bash", "*").
+
+| Attribute | Value |
+|-----------|-------|
+| **Type** | `object` |
+| **Default** | `{}` |
+
+## Nested Types
+
+This section uses the following nested type definitions:
+
+### `PermissionDeniedCommand` Type
+
+Configuration for individual permission-denied commands with optional messages.
+
+**Properties:**
+
+| Property | Type | Default | Description |
+|----------|------|---------|-------------|
+| `maxOutputLines` | `integer | null` | `null` | Maximum number of output lines to display (limits both stdout and stderr) |
+| `message` | `string | null` | `null` | Custom error message to display when the command fails (exits with non-zero status) |
+| `notifyPerCommand` | `boolean | null` | `null` | Whether to send individual notifications for this command |
+| `run` | `string` | - | The shell command to execute |
+| `showCommand` | `boolean | null` | `true` | Whether to show the command being executed to the user and Claude |
+| `showStderr` | `boolean | null` | `null` | Whether to show the command's standard error output to the user and Claude |
+| `showStdout` | `boolean | null` | `null` | Whether to show the command's standard output to the user and Claude |
+| `timeout` | `integer | null` | `null` | Optional command timeout in seconds |
+
+## See Also
+
+- [Configuration Overview](/conclaude/reference/config/configuration) - Complete reference for all configuration options

--- a/docs/src/content/docs/reference/config/post-tool-batch.md
+++ b/docs/src/content/docs/reference/config/post-tool-batch.md
@@ -1,0 +1,46 @@
+---
+title: Post Tool Batch
+description: Configuration options for postToolBatch
+---
+
+# Post Tool Batch
+
+Configuration for post-tool-batch hooks.
+
+Commands run once after every tool call in a batch resolves. Observational.
+
+## Configuration Properties
+
+### `commands`
+
+Commands to execute after each resolved tool batch. They run in order and are observational.
+
+| Attribute | Value |
+|-----------|-------|
+| **Type** | `array` |
+| **Default** | `[]` |
+
+## Nested Types
+
+This section uses the following nested type definitions:
+
+### `PostToolBatchCommand` Type
+
+Configuration for individual post-tool-batch commands with optional messages.
+
+**Properties:**
+
+| Property | Type | Default | Description |
+|----------|------|---------|-------------|
+| `maxOutputLines` | `integer | null` | `null` | Maximum number of output lines to display (limits both stdout and stderr) |
+| `message` | `string | null` | `null` | Custom error message to display when the command fails (exits with non-zero status) |
+| `notifyPerCommand` | `boolean | null` | `null` | Whether to send individual notifications for this command |
+| `run` | `string` | - | The shell command to execute |
+| `showCommand` | `boolean | null` | `true` | Whether to show the command being executed to the user and Claude |
+| `showStderr` | `boolean | null` | `null` | Whether to show the command's standard error output to the user and Claude |
+| `showStdout` | `boolean | null` | `null` | Whether to show the command's standard output to the user and Claude |
+| `timeout` | `integer | null` | `null` | Optional command timeout in seconds |
+
+## See Also
+
+- [Configuration Overview](/conclaude/reference/config/configuration) - Complete reference for all configuration options

--- a/docs/src/content/docs/reference/config/user-prompt-expansion.md
+++ b/docs/src/content/docs/reference/config/user-prompt-expansion.md
@@ -1,0 +1,46 @@
+---
+title: User Prompt Expansion
+description: Configuration options for userPromptExpansion
+---
+
+# User Prompt Expansion
+
+Configuration for user-prompt-expansion hooks with command-name-based command execution.
+
+Commands run when a slash command or MCP prompt is expanded. Observational.
+
+## Configuration Properties
+
+### `commands`
+
+Map of command-name patterns to command configurations. Keys are glob patterns matched against the expanded command name (e.g., "commit", "*").
+
+| Attribute | Value |
+|-----------|-------|
+| **Type** | `object` |
+| **Default** | `{}` |
+
+## Nested Types
+
+This section uses the following nested type definitions:
+
+### `UserPromptExpansionCommand` Type
+
+Configuration for individual user-prompt-expansion commands with optional messages.
+
+**Properties:**
+
+| Property | Type | Default | Description |
+|----------|------|---------|-------------|
+| `maxOutputLines` | `integer | null` | `null` | Maximum number of output lines to display (limits both stdout and stderr) |
+| `message` | `string | null` | `null` | Custom error message to display when the command fails (exits with non-zero status) |
+| `notifyPerCommand` | `boolean | null` | `null` | Whether to send individual notifications for this command |
+| `run` | `string` | - | The shell command to execute |
+| `showCommand` | `boolean | null` | `true` | Whether to show the command being executed to the user and Claude |
+| `showStderr` | `boolean | null` | `null` | Whether to show the command's standard error output to the user and Claude |
+| `showStdout` | `boolean | null` | `null` | Whether to show the command's standard output to the user and Claude |
+| `timeout` | `integer | null` | `null` | Optional command timeout in seconds |
+
+## See Also
+
+- [Configuration Overview](/conclaude/reference/config/configuration) - Complete reference for all configuration options

--- a/src/config.rs
+++ b/src/config.rs
@@ -698,6 +698,134 @@ pub struct InstructionsLoadedConfig {
     pub commands: std::collections::HashMap<String, Vec<InstructionsLoadedCommand>>,
 }
 
+/// Configuration for individual post-tool-batch commands with optional messages.
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, FieldList)]
+#[serde(deny_unknown_fields)]
+pub struct PostToolBatchCommand {
+    /// The shell command to execute. Environment variables are available: CONCLAUDE_TOOL_BATCH_SIZE, CONCLAUDE_TOOL_BATCH_NAMES, CONCLAUDE_SESSION_ID, CONCLAUDE_TRANSCRIPT_PATH, CONCLAUDE_HOOK_EVENT, CONCLAUDE_CWD, CONCLAUDE_CONFIG_DIR, CONCLAUDE_PAYLOAD_JSON
+    pub run: String,
+    /// Custom error message to display when the command fails (exits with non-zero status)
+    #[serde(default)]
+    pub message: Option<String>,
+    /// Whether to show the command being executed to the user and Claude. Default: true
+    #[serde(default = "default_option_true", rename = "showCommand")]
+    pub show_command: Option<bool>,
+    /// Whether to show the command's standard output to the user and Claude. Default: false
+    #[serde(default, rename = "showStdout")]
+    pub show_stdout: Option<bool>,
+    /// Whether to show the command's standard error output to the user and Claude. Default: false
+    #[serde(default, rename = "showStderr")]
+    pub show_stderr: Option<bool>,
+    /// Maximum number of output lines to display (limits both stdout and stderr). Range: 1-10000
+    #[serde(default, rename = "maxOutputLines")]
+    #[schemars(range(min = 1, max = 10000))]
+    pub max_output_lines: Option<u32>,
+    /// Optional command timeout in seconds. Range: 1-3600 (1 second to 1 hour).
+    #[serde(default)]
+    #[schemars(range(min = 1, max = 3600))]
+    pub timeout: Option<u64>,
+    /// Whether to send individual notifications for this command. Default: false
+    #[serde(default, rename = "notifyPerCommand")]
+    pub notify_per_command: Option<bool>,
+}
+
+/// Configuration for individual permission-denied commands with optional messages.
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, FieldList)]
+#[serde(deny_unknown_fields)]
+pub struct PermissionDeniedCommand {
+    /// The shell command to execute. Environment variables are available: CONCLAUDE_TOOL_NAME, CONCLAUDE_DENY_REASON, CONCLAUDE_TOOL_USE_ID, CONCLAUDE_SESSION_ID, CONCLAUDE_TRANSCRIPT_PATH, CONCLAUDE_HOOK_EVENT, CONCLAUDE_CWD, CONCLAUDE_CONFIG_DIR, CONCLAUDE_PAYLOAD_JSON
+    pub run: String,
+    /// Custom error message to display when the command fails (exits with non-zero status)
+    #[serde(default)]
+    pub message: Option<String>,
+    /// Whether to show the command being executed to the user and Claude. Default: true
+    #[serde(default = "default_option_true", rename = "showCommand")]
+    pub show_command: Option<bool>,
+    /// Whether to show the command's standard output to the user and Claude. Default: false
+    #[serde(default, rename = "showStdout")]
+    pub show_stdout: Option<bool>,
+    /// Whether to show the command's standard error output to the user and Claude. Default: false
+    #[serde(default, rename = "showStderr")]
+    pub show_stderr: Option<bool>,
+    /// Maximum number of output lines to display (limits both stdout and stderr). Range: 1-10000
+    #[serde(default, rename = "maxOutputLines")]
+    #[schemars(range(min = 1, max = 10000))]
+    pub max_output_lines: Option<u32>,
+    /// Optional command timeout in seconds. Range: 1-3600 (1 second to 1 hour).
+    #[serde(default)]
+    #[schemars(range(min = 1, max = 3600))]
+    pub timeout: Option<u64>,
+    /// Whether to send individual notifications for this command. Default: false
+    #[serde(default, rename = "notifyPerCommand")]
+    pub notify_per_command: Option<bool>,
+}
+
+/// Configuration for individual user-prompt-expansion commands with optional messages.
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, FieldList)]
+#[serde(deny_unknown_fields)]
+pub struct UserPromptExpansionCommand {
+    /// The shell command to execute. Environment variables are available: CONCLAUDE_EXPANSION_TYPE, CONCLAUDE_COMMAND_NAME, CONCLAUDE_COMMAND_ARGS, CONCLAUDE_COMMAND_SOURCE, CONCLAUDE_EXPANDED_PROMPT, CONCLAUDE_SESSION_ID, CONCLAUDE_TRANSCRIPT_PATH, CONCLAUDE_HOOK_EVENT, CONCLAUDE_CWD, CONCLAUDE_CONFIG_DIR, CONCLAUDE_PAYLOAD_JSON
+    pub run: String,
+    /// Custom error message to display when the command fails (exits with non-zero status)
+    #[serde(default)]
+    pub message: Option<String>,
+    /// Whether to show the command being executed to the user and Claude. Default: true
+    #[serde(default = "default_option_true", rename = "showCommand")]
+    pub show_command: Option<bool>,
+    /// Whether to show the command's standard output to the user and Claude. Default: false
+    #[serde(default, rename = "showStdout")]
+    pub show_stdout: Option<bool>,
+    /// Whether to show the command's standard error output to the user and Claude. Default: false
+    #[serde(default, rename = "showStderr")]
+    pub show_stderr: Option<bool>,
+    /// Maximum number of output lines to display (limits both stdout and stderr). Range: 1-10000
+    #[serde(default, rename = "maxOutputLines")]
+    #[schemars(range(min = 1, max = 10000))]
+    pub max_output_lines: Option<u32>,
+    /// Optional command timeout in seconds. Range: 1-3600 (1 second to 1 hour).
+    #[serde(default)]
+    #[schemars(range(min = 1, max = 3600))]
+    pub timeout: Option<u64>,
+    /// Whether to send individual notifications for this command. Default: false
+    #[serde(default, rename = "notifyPerCommand")]
+    pub notify_per_command: Option<bool>,
+}
+
+/// Configuration for post-tool-batch hooks.
+///
+/// Commands run once after every tool call in a batch resolves. Observational.
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, Default, FieldList)]
+#[serde(deny_unknown_fields)]
+pub struct PostToolBatchConfig {
+    /// Commands to execute after each resolved tool batch. They run in order and are observational.
+    #[serde(default)]
+    pub commands: Vec<PostToolBatchCommand>,
+}
+
+/// Configuration for permission-denied hooks with tool-based command execution.
+///
+/// Commands run when a tool permission request is denied. Observational.
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, Default, FieldList)]
+#[serde(deny_unknown_fields)]
+pub struct PermissionDeniedConfig {
+    /// Map of tool-name patterns to command configurations.
+    /// Keys are glob patterns matched against the denied tool name (e.g., "Bash", "*").
+    #[serde(default)]
+    pub commands: std::collections::HashMap<String, Vec<PermissionDeniedCommand>>,
+}
+
+/// Configuration for user-prompt-expansion hooks with command-name-based command execution.
+///
+/// Commands run when a slash command or MCP prompt is expanded. Observational.
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, Default, FieldList)]
+#[serde(deny_unknown_fields)]
+pub struct UserPromptExpansionConfig {
+    /// Map of command-name patterns to command configurations.
+    /// Keys are glob patterns matched against the expanded command name (e.g., "commit", "*").
+    #[serde(default)]
+    pub commands: std::collections::HashMap<String, Vec<UserPromptExpansionCommand>>,
+}
+
 /// Configuration for stop hook commands that run when Claude is about to stop
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, Default, FieldList)]
 #[serde(deny_unknown_fields)]
@@ -1525,6 +1653,15 @@ pub struct ConclaudeConfig {
     /// Configuration for instructions-loaded hooks that run when an instructions/memory file loads.
     #[serde(default, rename = "instructionsLoaded")]
     pub instructions_loaded: InstructionsLoadedConfig,
+    /// Configuration for post-tool-batch hooks that run after each resolved tool batch.
+    #[serde(default, rename = "postToolBatch")]
+    pub post_tool_batch: PostToolBatchConfig,
+    /// Configuration for permission-denied hooks that run when a tool permission is denied.
+    #[serde(default, rename = "permissionDenied")]
+    pub permission_denied: PermissionDeniedConfig,
+    /// Configuration for user-prompt-expansion hooks that run when a command/prompt expands.
+    #[serde(default, rename = "userPromptExpansion")]
+    pub user_prompt_expansion: UserPromptExpansionConfig,
 }
 
 /// Extract the field name from an unknown field error message

--- a/src/hooks.rs
+++ b/src/hooks.rs
@@ -1,23 +1,26 @@
 use crate::config::{
     extract_bash_commands, load_conclaude_config, ConclaudeConfig, ConfigChangeConfig,
-    CwdChangedConfig, FileChangedConfig, InstructionsLoadedConfig, PostCompactConfig, SetupConfig,
-    SkillStartConfig, SlashCommandConfig, SubagentStopConfig, TaskCompletedConfig,
-    TeammateIdleConfig, UserPromptSubmitCommand,
+    CwdChangedConfig, FileChangedConfig, InstructionsLoadedConfig, PermissionDeniedConfig,
+    PostCompactConfig, PostToolBatchConfig, SetupConfig, SkillStartConfig, SlashCommandConfig,
+    SubagentStopConfig, TaskCompletedConfig, TeammateIdleConfig, UserPromptExpansionConfig,
+    UserPromptSubmitCommand,
 };
 use crate::gitignore::{find_git_root, is_path_git_ignored};
 use crate::types::{
     validate_base_payload, validate_cwd_changed_payload, validate_file_changed_payload,
-    validate_instructions_loaded_payload, validate_permission_request_payload,
-    validate_post_compact_payload, validate_setup_payload, validate_stop_failure_payload,
+    validate_instructions_loaded_payload, validate_permission_denied_payload,
+    validate_permission_request_payload, validate_post_compact_payload,
+    validate_post_tool_batch_payload, validate_setup_payload, validate_stop_failure_payload,
     validate_subagent_start_payload, validate_subagent_stop_payload,
     validate_task_completed_payload, validate_teammate_idle_payload,
-    validate_worktree_create_payload, validate_worktree_remove_payload, ConfigChangePayload,
-    ConfigChangeSource, CwdChangedPayload, FileChangedPayload, HookResult,
-    InstructionsLoadedPayload, NotificationPayload, PermissionRequestPayload, PostCompactPayload,
+    validate_user_prompt_expansion_payload, validate_worktree_create_payload,
+    validate_worktree_remove_payload, ConfigChangePayload, ConfigChangeSource, CwdChangedPayload,
+    FileChangedPayload, HookResult, InstructionsLoadedPayload, NotificationPayload,
+    PermissionDeniedPayload, PermissionRequestPayload, PostCompactPayload, PostToolBatchPayload,
     PostToolUseFailurePayload, PostToolUsePayload, PreCompactPayload, PreToolUsePayload,
     SessionEndPayload, SessionStartPayload, SetupPayload, StopFailurePayload, StopPayload,
     SubagentStartPayload, SubagentStopPayload, TaskCompletedPayload, TeammateIdlePayload,
-    UserPromptSubmitPayload, WorktreeCreatePayload, WorktreeRemovePayload,
+    UserPromptExpansionPayload, UserPromptSubmitPayload, WorktreeCreatePayload, WorktreeRemovePayload,
 };
 use anyhow::{Context, Result};
 use glob::Pattern;
@@ -208,6 +211,9 @@ pub(crate) fn is_system_event_hook(hook_name: &str) -> bool {
             | "CwdChanged"
             | "FileChanged"
             | "InstructionsLoaded"
+            | "PostToolBatch"
+            | "PermissionDenied"
+            | "UserPromptExpansion"
     )
 }
 
@@ -4790,6 +4796,283 @@ pub async fn handle_instructions_loaded() -> Result<HookResult> {
             payload.file_path
         )),
     );
+    Ok(HookResult::success())
+}
+
+/// Collect commands from `PostToolBatchConfig` (flat command list).
+fn collect_post_tool_batch_commands(
+    config: &PostToolBatchConfig,
+) -> Result<Vec<GenericCommandConfig>> {
+    let mut commands = Vec::new();
+    for cmd_config in &config.commands {
+        for cmd in extract_bash_commands(&cmd_config.run)? {
+            commands.push(GenericCommandConfig {
+                command: cmd,
+                message: cmd_config.message.clone(),
+                show_stdout: cmd_config.show_stdout.unwrap_or(false),
+                show_stderr: cmd_config.show_stderr.unwrap_or(false),
+                max_output_lines: cmd_config.max_output_lines,
+                timeout: cmd_config.timeout,
+                show_command: cmd_config.show_command.unwrap_or(true),
+                notify_per_command: cmd_config.notify_per_command.unwrap_or(false),
+            });
+        }
+    }
+    Ok(commands)
+}
+
+/// Collect commands from `PermissionDeniedConfig` for matching patterns.
+fn collect_permission_denied_commands(
+    config: &PermissionDeniedConfig,
+    matching_patterns: &[&str],
+) -> Result<Vec<GenericCommandConfig>> {
+    let mut commands = Vec::new();
+    for pattern in matching_patterns {
+        if let Some(cmd_list) = config.commands.get(*pattern) {
+            for cmd_config in cmd_list {
+                for cmd in extract_bash_commands(&cmd_config.run)? {
+                    commands.push(GenericCommandConfig {
+                        command: cmd,
+                        message: cmd_config.message.clone(),
+                        show_stdout: cmd_config.show_stdout.unwrap_or(false),
+                        show_stderr: cmd_config.show_stderr.unwrap_or(false),
+                        max_output_lines: cmd_config.max_output_lines,
+                        timeout: cmd_config.timeout,
+                        show_command: cmd_config.show_command.unwrap_or(true),
+                        notify_per_command: cmd_config.notify_per_command.unwrap_or(false),
+                    });
+                }
+            }
+        }
+    }
+    Ok(commands)
+}
+
+/// Collect commands from `UserPromptExpansionConfig` for matching patterns.
+fn collect_user_prompt_expansion_commands(
+    config: &UserPromptExpansionConfig,
+    matching_patterns: &[&str],
+) -> Result<Vec<GenericCommandConfig>> {
+    let mut commands = Vec::new();
+    for pattern in matching_patterns {
+        if let Some(cmd_list) = config.commands.get(*pattern) {
+            for cmd_config in cmd_list {
+                for cmd in extract_bash_commands(&cmd_config.run)? {
+                    commands.push(GenericCommandConfig {
+                        command: cmd,
+                        message: cmd_config.message.clone(),
+                        show_stdout: cmd_config.show_stdout.unwrap_or(false),
+                        show_stderr: cmd_config.show_stderr.unwrap_or(false),
+                        max_output_lines: cmd_config.max_output_lines,
+                        timeout: cmd_config.timeout,
+                        show_command: cmd_config.show_command.unwrap_or(true),
+                        notify_per_command: cmd_config.notify_per_command.unwrap_or(false),
+                    });
+                }
+            }
+        }
+    }
+    Ok(commands)
+}
+
+/// Handles `PostToolBatch` hook events fired once after a batch of tool calls resolves.
+/// Observational - it cannot block.
+///
+/// # Errors
+///
+/// Returns an error if payload reading or validation fails.
+pub async fn handle_post_tool_batch() -> Result<HookResult> {
+    let payload: PostToolBatchPayload = read_payload_from_stdin()?;
+    validate_post_tool_batch_payload(&payload).map_err(|e| anyhow::anyhow!(e))?;
+
+    let batch_size = payload.tool_calls.len();
+    let tool_names: Vec<&str> = payload
+        .tool_calls
+        .iter()
+        .map(|tc| tc.tool_name.as_str())
+        .collect();
+    let names_csv = tool_names.join(",");
+    println!(
+        "Processing PostToolBatch hook: session_id={}, batch_size={}, tools=[{}]",
+        payload.base.session_id, batch_size, names_csv
+    );
+
+    let agent_name = std::env::var(AGENT_ENV_VAR).ok();
+    if let Some(ref name) = agent_name {
+        std::env::set_var("CONCLAUDE_AGENT_NAME", name);
+    }
+    std::env::set_var("CONCLAUDE_TOOL_BATCH_SIZE", batch_size.to_string());
+    std::env::set_var("CONCLAUDE_TOOL_BATCH_NAMES", &names_csv);
+
+    let (config, config_path) = get_config().await?;
+    let config_dir = get_config_dir(config_path);
+
+    if !config.post_tool_batch.commands.is_empty() {
+        let commands = collect_post_tool_batch_commands(&config.post_tool_batch)?;
+        if !commands.is_empty() {
+            let mut env_vars = HashMap::new();
+            env_vars.insert(
+                "CONCLAUDE_TOOL_BATCH_SIZE".to_string(),
+                batch_size.to_string(),
+            );
+            env_vars.insert("CONCLAUDE_TOOL_BATCH_NAMES".to_string(), names_csv.clone());
+            insert_base_env_vars(
+                &mut env_vars,
+                &payload.base,
+                &payload,
+                "PostToolBatch",
+                config_dir,
+            );
+            let _ =
+                execute_generic_commands(&commands, &env_vars, config_dir, "PostToolBatch").await;
+        }
+    }
+
+    Ok(HookResult::success())
+}
+
+/// Handles `PermissionDenied` hook events fired when a tool permission request is denied.
+/// Observational - it cannot block.
+///
+/// # Errors
+///
+/// Returns an error if payload reading or validation fails.
+pub async fn handle_permission_denied() -> Result<HookResult> {
+    let payload: PermissionDeniedPayload = read_payload_from_stdin()?;
+    validate_permission_denied_payload(&payload).map_err(|e| anyhow::anyhow!(e))?;
+
+    println!(
+        "Processing PermissionDenied hook: session_id={}, tool_name={}, reason={}",
+        payload.base.session_id, payload.tool_name, payload.reason
+    );
+
+    let agent_name = std::env::var(AGENT_ENV_VAR).ok();
+    if let Some(ref name) = agent_name {
+        std::env::set_var("CONCLAUDE_AGENT_NAME", name);
+    }
+    std::env::set_var("CONCLAUDE_TOOL_NAME", &payload.tool_name);
+    std::env::set_var("CONCLAUDE_DENY_REASON", &payload.reason);
+    std::env::set_var("CONCLAUDE_TOOL_USE_ID", &payload.tool_use_id);
+
+    let (config, config_path) = get_config().await?;
+    let config_dir = get_config_dir(config_path);
+
+    if !config.permission_denied.commands.is_empty() {
+        let matching_patterns =
+            match_generic_patterns(&payload.tool_name, &config.permission_denied.commands)?;
+        if !matching_patterns.is_empty() {
+            let commands =
+                collect_permission_denied_commands(&config.permission_denied, &matching_patterns)?;
+            if !commands.is_empty() {
+                let mut env_vars = HashMap::new();
+                env_vars.insert("CONCLAUDE_TOOL_NAME".to_string(), payload.tool_name.clone());
+                env_vars.insert("CONCLAUDE_DENY_REASON".to_string(), payload.reason.clone());
+                env_vars.insert(
+                    "CONCLAUDE_TOOL_USE_ID".to_string(),
+                    payload.tool_use_id.clone(),
+                );
+                insert_base_env_vars(
+                    &mut env_vars,
+                    &payload.base,
+                    &payload,
+                    "PermissionDenied",
+                    config_dir,
+                );
+                let _ =
+                    execute_generic_commands(&commands, &env_vars, config_dir, "PermissionDenied")
+                        .await;
+            }
+        }
+    }
+
+    send_notification(
+        "PermissionDenied",
+        "warning",
+        Some(&format!(
+            "Permission denied for '{}': {}",
+            payload.tool_name, payload.reason
+        )),
+    );
+    Ok(HookResult::success())
+}
+
+/// Handles `UserPromptExpansion` hook events fired when a slash command or MCP prompt expands.
+/// Observational - it cannot block.
+///
+/// # Errors
+///
+/// Returns an error if payload reading or validation fails.
+pub async fn handle_user_prompt_expansion() -> Result<HookResult> {
+    let payload: UserPromptExpansionPayload = read_payload_from_stdin()?;
+    validate_user_prompt_expansion_payload(&payload).map_err(|e| anyhow::anyhow!(e))?;
+
+    let expansion_type_str = payload.expansion_type.to_string();
+    println!(
+        "Processing UserPromptExpansion hook: session_id={}, expansion_type={}, command_name={}",
+        payload.base.session_id, expansion_type_str, payload.command_name
+    );
+
+    let agent_name = std::env::var(AGENT_ENV_VAR).ok();
+    if let Some(ref name) = agent_name {
+        std::env::set_var("CONCLAUDE_AGENT_NAME", name);
+    }
+    std::env::set_var("CONCLAUDE_EXPANSION_TYPE", &expansion_type_str);
+    std::env::set_var("CONCLAUDE_COMMAND_NAME", &payload.command_name);
+    std::env::set_var("CONCLAUDE_COMMAND_ARGS", &payload.command_args);
+    std::env::set_var(
+        "CONCLAUDE_COMMAND_SOURCE",
+        payload.command_source.as_deref().unwrap_or(""),
+    );
+    std::env::set_var("CONCLAUDE_EXPANDED_PROMPT", &payload.prompt);
+
+    let (config, config_path) = get_config().await?;
+    let config_dir = get_config_dir(config_path);
+
+    if !config.user_prompt_expansion.commands.is_empty() {
+        let matching_patterns =
+            match_generic_patterns(&payload.command_name, &config.user_prompt_expansion.commands)?;
+        if !matching_patterns.is_empty() {
+            let commands = collect_user_prompt_expansion_commands(
+                &config.user_prompt_expansion,
+                &matching_patterns,
+            )?;
+            if !commands.is_empty() {
+                let mut env_vars = HashMap::new();
+                env_vars.insert(
+                    "CONCLAUDE_EXPANSION_TYPE".to_string(),
+                    expansion_type_str.clone(),
+                );
+                env_vars.insert(
+                    "CONCLAUDE_COMMAND_NAME".to_string(),
+                    payload.command_name.clone(),
+                );
+                env_vars.insert(
+                    "CONCLAUDE_COMMAND_ARGS".to_string(),
+                    payload.command_args.clone(),
+                );
+                env_vars.insert(
+                    "CONCLAUDE_COMMAND_SOURCE".to_string(),
+                    payload.command_source.clone().unwrap_or_default(),
+                );
+                env_vars.insert("CONCLAUDE_EXPANDED_PROMPT".to_string(), payload.prompt.clone());
+                insert_base_env_vars(
+                    &mut env_vars,
+                    &payload.base,
+                    &payload,
+                    "UserPromptExpansion",
+                    config_dir,
+                );
+                let _ = execute_generic_commands(
+                    &commands,
+                    &env_vars,
+                    config_dir,
+                    "UserPromptExpansion",
+                )
+                .await;
+            }
+        }
+    }
+
     Ok(HookResult::success())
 }
 

--- a/src/hooks_tests.rs
+++ b/src/hooks_tests.rs
@@ -33,6 +33,9 @@ fn test_is_system_event_hook_new_hooks() {
     assert!(is_system_event_hook("CwdChanged"));
     assert!(is_system_event_hook("FileChanged"));
     assert!(is_system_event_hook("InstructionsLoaded"));
+    assert!(is_system_event_hook("PostToolBatch"));
+    assert!(is_system_event_hook("PermissionDenied"));
+    assert!(is_system_event_hook("UserPromptExpansion"));
 
     // PostToolUseFailure is NOT a system event hook
     assert!(!is_system_event_hook("PostToolUseFailure"));

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,12 +9,12 @@ use anyhow::{Context, Result};
 use clap::{Parser, Subcommand};
 use hooks::{
     handle_config_change, handle_cwd_changed, handle_file_changed, handle_hook_result,
-    handle_instructions_loaded, handle_notification, handle_permission_request,
-    handle_post_compact, handle_post_tool_use, handle_post_tool_use_failure, handle_pre_compact,
-    handle_pre_tool_use, handle_session_end, handle_session_start, handle_setup, handle_stop,
-    handle_stop_failure, handle_subagent_start, handle_subagent_stop, handle_task_completed,
-    handle_teammate_idle, handle_user_prompt_submit, handle_worktree_create_result,
-    handle_worktree_remove,
+    handle_instructions_loaded, handle_notification, handle_permission_denied,
+    handle_permission_request, handle_post_compact, handle_post_tool_batch, handle_post_tool_use,
+    handle_post_tool_use_failure, handle_pre_compact, handle_pre_tool_use, handle_session_end,
+    handle_session_start, handle_setup, handle_stop, handle_stop_failure, handle_subagent_start,
+    handle_subagent_stop, handle_task_completed, handle_teammate_idle, handle_user_prompt_expansion,
+    handle_user_prompt_submit, handle_worktree_create_result, handle_worktree_remove,
 };
 use std::fs;
 use std::path::{Path, PathBuf};
@@ -251,6 +251,27 @@ enum HooksCommands {
         #[clap(long)]
         agent: Option<String>,
     },
+    /// Process `PostToolBatch` hook - fired once after a batch of tool calls resolves
+    #[clap(name = "PostToolBatch")]
+    PostToolBatch {
+        /// Optional agent name for context-aware hook execution
+        #[clap(long)]
+        agent: Option<String>,
+    },
+    /// Process `PermissionDenied` hook - fired when a tool permission request is denied
+    #[clap(name = "PermissionDenied")]
+    PermissionDenied {
+        /// Optional agent name for context-aware hook execution
+        #[clap(long)]
+        agent: Option<String>,
+    },
+    /// Process `UserPromptExpansion` hook - fired when a slash command or MCP prompt expands
+    #[clap(name = "UserPromptExpansion")]
+    UserPromptExpansion {
+        /// Optional agent name for context-aware hook execution
+        #[clap(long)]
+        agent: Option<String>,
+    },
 }
 
 #[tokio::main]
@@ -356,6 +377,18 @@ async fn main() -> Result<()> {
             HooksCommands::InstructionsLoaded { agent } => {
                 set_agent_env(agent.as_deref());
                 handle_hook_result(handle_instructions_loaded).await
+            }
+            HooksCommands::PostToolBatch { agent } => {
+                set_agent_env(agent.as_deref());
+                handle_hook_result(handle_post_tool_batch).await
+            }
+            HooksCommands::PermissionDenied { agent } => {
+                set_agent_env(agent.as_deref());
+                handle_hook_result(handle_permission_denied).await
+            }
+            HooksCommands::UserPromptExpansion { agent } => {
+                set_agent_env(agent.as_deref());
+                handle_hook_result(handle_user_prompt_expansion).await
             }
         },
         Commands::Visualize { rule, show_matches } => handle_visualize(rule, show_matches).await,
@@ -550,6 +583,9 @@ async fn handle_init(
         "CwdChanged",
         "FileChanged",
         "InstructionsLoaded",
+        "PostToolBatch",
+        "PermissionDenied",
+        "UserPromptExpansion",
     ];
 
     // Add hook configurations using merge logic to preserve user-defined hooks
@@ -698,6 +734,9 @@ fn generate_agent_hooks(agent_name: &str) -> serde_yaml::Value {
         ("CwdChanged", false),
         ("FileChanged", true), // needs matcher (file_path)
         ("InstructionsLoaded", true), // needs matcher (memory_type)
+        ("PostToolBatch", false),
+        ("PermissionDenied", true), // needs matcher (tool_name)
+        ("UserPromptExpansion", true), // needs matcher (command_name)
     ];
 
     let mut hooks_map = Mapping::new();

--- a/src/types.rs
+++ b/src/types.rs
@@ -799,6 +799,108 @@ pub fn validate_instructions_loaded_payload(
     Ok(())
 }
 
+/// A single tool call within a `PostToolBatch` event.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PostToolBatchToolCall {
+    /// Name of the tool that was executed
+    pub tool_name: String,
+    /// Input parameters that were passed to the tool
+    pub tool_input: serde_json::Value,
+    /// Unique identifier for this tool invocation
+    pub tool_use_id: String,
+    /// Response data returned by the tool execution, when available
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub tool_response: Option<serde_json::Value>,
+}
+
+/// Payload for `PostToolBatch` hook - fired once after every tool call in a batch
+/// has resolved, before the next model request. Observational.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PostToolBatchPayload {
+    #[serde(flatten)]
+    pub base: BasePayload,
+    /// All tool calls that resolved in this batch
+    pub tool_calls: Vec<PostToolBatchToolCall>,
+}
+
+/// Payload for `PermissionDenied` hook - fired when a tool permission request is denied.
+/// Observational.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PermissionDeniedPayload {
+    #[serde(flatten)]
+    pub base: BasePayload,
+    /// Name of the tool whose permission was denied
+    pub tool_name: String,
+    /// Input parameters for the denied tool
+    pub tool_input: serde_json::Value,
+    /// Unique identifier for the denied tool invocation
+    pub tool_use_id: String,
+    /// Reason the permission was denied
+    pub reason: String,
+}
+
+/// Type of expansion that produced a `UserPromptExpansion` event.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "snake_case")]
+pub enum ExpansionType {
+    SlashCommand,
+    McpPrompt,
+}
+
+impl std::fmt::Display for ExpansionType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            ExpansionType::SlashCommand => write!(f, "slash_command"),
+            ExpansionType::McpPrompt => write!(f, "mcp_prompt"),
+        }
+    }
+}
+
+/// Payload for `UserPromptExpansion` hook - fired when a slash command or MCP prompt
+/// is expanded into prompt text. Observational.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct UserPromptExpansionPayload {
+    #[serde(flatten)]
+    pub base: BasePayload,
+    /// Whether the expansion came from a slash command or an MCP prompt
+    pub expansion_type: ExpansionType,
+    /// Name of the command/prompt being expanded
+    pub command_name: String,
+    /// Arguments passed to the command/prompt
+    pub command_args: String,
+    /// Source of the command, when available (e.g. plugin or file origin)
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub command_source: Option<String>,
+    /// The expanded prompt text
+    pub prompt: String,
+}
+
+/// Validates that a `PostToolBatchPayload` contains all required fields.
+pub fn validate_post_tool_batch_payload(payload: &PostToolBatchPayload) -> Result<(), String> {
+    validate_base_payload(&payload.base)?;
+    Ok(())
+}
+
+/// Validates that a `PermissionDeniedPayload` contains all required fields.
+pub fn validate_permission_denied_payload(payload: &PermissionDeniedPayload) -> Result<(), String> {
+    validate_base_payload(&payload.base)?;
+    if payload.tool_name.trim().is_empty() {
+        return Err("tool_name cannot be empty".to_string());
+    }
+    Ok(())
+}
+
+/// Validates that a `UserPromptExpansionPayload` contains all required fields.
+pub fn validate_user_prompt_expansion_payload(
+    payload: &UserPromptExpansionPayload,
+) -> Result<(), String> {
+    validate_base_payload(&payload.base)?;
+    if payload.command_name.trim().is_empty() {
+        return Err("command_name cannot be empty".to_string());
+    }
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1710,5 +1812,89 @@ mod tests {
         assert_eq!(payload.globs, Some(vec!["**/*.rs".to_string()]));
         assert_eq!(payload.trigger_file_path, Some("/repo/sub/lib.rs".to_string()));
         assert_eq!(payload.parent_file_path, Some("/repo/CLAUDE.md".to_string()));
+    }
+
+    #[test]
+    fn test_post_tool_batch_payload_deserialization() {
+        let json = r#"{
+            "session_id": "s",
+            "transcript_path": "/t",
+            "hook_event_name": "PostToolBatch",
+            "cwd": "/c",
+            "tool_calls": [
+                {"tool_name": "Read", "tool_input": {"file_path": "a.rs"}, "tool_use_id": "tu_1", "tool_response": {"ok": true}},
+                {"tool_name": "Bash", "tool_input": {"command": "ls"}, "tool_use_id": "tu_2"}
+            ]
+        }"#;
+        let payload: PostToolBatchPayload = serde_json::from_str(json).unwrap();
+        assert_eq!(payload.tool_calls.len(), 2);
+        assert_eq!(payload.tool_calls[0].tool_name, "Read");
+        assert_eq!(payload.tool_calls[0].tool_use_id, "tu_1");
+        assert!(payload.tool_calls[0].tool_response.is_some());
+        assert_eq!(payload.tool_calls[1].tool_name, "Bash");
+        assert!(payload.tool_calls[1].tool_response.is_none());
+        assert!(validate_post_tool_batch_payload(&payload).is_ok());
+    }
+
+    #[test]
+    fn test_permission_denied_payload_deserialization() {
+        let json = r#"{
+            "session_id": "s",
+            "transcript_path": "/t",
+            "hook_event_name": "PermissionDenied",
+            "cwd": "/c",
+            "tool_name": "Bash",
+            "tool_input": {"command": "rm -rf /"},
+            "tool_use_id": "tu_9",
+            "reason": "destructive command blocked by policy"
+        }"#;
+        let payload: PermissionDeniedPayload = serde_json::from_str(json).unwrap();
+        assert_eq!(payload.tool_name, "Bash");
+        assert_eq!(payload.tool_use_id, "tu_9");
+        assert_eq!(payload.reason, "destructive command blocked by policy");
+        assert!(validate_permission_denied_payload(&payload).is_ok());
+
+        let mut empty_tool = payload.clone();
+        empty_tool.tool_name = "  ".to_string();
+        assert!(validate_permission_denied_payload(&empty_tool).is_err());
+    }
+
+    #[test]
+    fn test_user_prompt_expansion_payload_deserialization() {
+        let json = r#"{
+            "session_id": "s",
+            "transcript_path": "/t",
+            "hook_event_name": "UserPromptExpansion",
+            "cwd": "/c",
+            "expansion_type": "slash_command",
+            "command_name": "commit",
+            "command_args": "--amend",
+            "prompt": "Create a git commit"
+        }"#;
+        let payload: UserPromptExpansionPayload = serde_json::from_str(json).unwrap();
+        assert_eq!(payload.expansion_type, ExpansionType::SlashCommand);
+        assert_eq!(payload.expansion_type.to_string(), "slash_command");
+        assert_eq!(payload.command_name, "commit");
+        assert_eq!(payload.command_args, "--amend");
+        assert_eq!(payload.command_source, None);
+        assert!(validate_user_prompt_expansion_payload(&payload).is_ok());
+    }
+
+    #[test]
+    fn test_user_prompt_expansion_payload_mcp_prompt() {
+        let json = r#"{
+            "session_id": "s",
+            "transcript_path": "/t",
+            "hook_event_name": "UserPromptExpansion",
+            "cwd": "/c",
+            "expansion_type": "mcp_prompt",
+            "command_name": "summarize",
+            "command_args": "",
+            "command_source": "my-mcp-server",
+            "prompt": "Summarize the doc"
+        }"#;
+        let payload: UserPromptExpansionPayload = serde_json::from_str(json).unwrap();
+        assert_eq!(payload.expansion_type, ExpansionType::McpPrompt);
+        assert_eq!(payload.command_source, Some("my-mcp-server".to_string()));
     }
 }


### PR DESCRIPTION
## Summary
Third in the sequential series adding new Claude Code hook events from `@anthropic-ai/claude-agent-sdk`. Adds three more observational hooks:

| Hook | Config shape | Env vars exposed |
|------|--------------|------------------|
| `PostToolBatch` | flat command list (runs after every batch) | `CONCLAUDE_TOOL_BATCH_SIZE`, `CONCLAUDE_TOOL_BATCH_NAMES` |
| `PermissionDenied` | keyed by tool_name glob | `CONCLAUDE_TOOL_NAME`, `CONCLAUDE_DENY_REASON`, `CONCLAUDE_TOOL_USE_ID` |
| `UserPromptExpansion` | keyed by command_name glob | `CONCLAUDE_EXPANSION_TYPE`, `CONCLAUDE_COMMAND_NAME`, `CONCLAUDE_COMMAND_ARGS`, `CONCLAUDE_COMMAND_SOURCE`, `CONCLAUDE_EXPANDED_PROMPT` |

All three are **observational** (commands run but cannot block, matching SDK semantics). Adds payload + config types (`PostToolBatchToolCall`, `ExpansionType`), handlers, CLI subcommands, `init`/agent-hook wiring, `is_system_event_hook` registration, regenerated schema + docs, and deserialization/validation tests.

## Testing
- `cargo clippy --all-targets --all-features` — clean
- `cargo test` — all pass
- docs build — green

## Remaining (final PR)
TaskCreated, Elicitation, ElicitationResult, MessageDisplay.

🤖 Generated with [Claude Code](https://claude.com/claude-code)