### PR TITLE
feat: add TaskCreated, Elicitation, ElicitationResult, MessageDisplay hooks

### DIFF
--- a/conclaude-schema.json
+++ b/conclaude-schema.json
@@ -226,6 +226,194 @@
       },
       "type": "object"
     },
+    "ElicitationCommand": {
+      "additionalProperties": false,
+      "description": "Configuration for individual elicitation commands with optional messages.",
+      "properties": {
+        "maxOutputLines": {
+          "default": null,
+          "description": "Maximum number of output lines to display (limits both stdout and stderr). Range: 1-10000",
+          "format": "uint32",
+          "maximum": 10000.0,
+          "minimum": 1.0,
+          "type": [
+            "integer",
+            "null"
+          ]
+        },
+        "message": {
+          "default": null,
+          "description": "Custom error message to display when the command fails (exits with non-zero status)",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "notifyPerCommand": {
+          "default": null,
+          "description": "Whether to send individual notifications for this command. Default: false",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "run": {
+          "description": "The shell command to execute. Environment variables are available: CONCLAUDE_MCP_SERVER_NAME, CONCLAUDE_ELICITATION_MESSAGE, CONCLAUDE_ELICITATION_MODE, CONCLAUDE_ELICITATION_ID, CONCLAUDE_SESSION_ID, CONCLAUDE_TRANSCRIPT_PATH, CONCLAUDE_HOOK_EVENT, CONCLAUDE_CWD, CONCLAUDE_CONFIG_DIR",
+          "type": "string"
+        },
+        "showCommand": {
+          "default": true,
+          "description": "Whether to show the command being executed to the user and Claude. Default: true",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "showStderr": {
+          "default": null,
+          "description": "Whether to show the command's standard error output to the user and Claude. Default: false",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "showStdout": {
+          "default": null,
+          "description": "Whether to show the command's standard output to the user and Claude. Default: false",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "timeout": {
+          "default": null,
+          "description": "Optional command timeout in seconds. Range: 1-3600 (1 second to 1 hour).",
+          "format": "uint64",
+          "maximum": 3600.0,
+          "minimum": 1.0,
+          "type": [
+            "integer",
+            "null"
+          ]
+        }
+      },
+      "required": [
+        "run"
+      ],
+      "type": "object"
+    },
+    "ElicitationConfig": {
+      "additionalProperties": false,
+      "description": "Configuration for elicitation hooks with MCP-server-based command execution.\n\nCommands run when an MCP server requests user input. Observational.",
+      "properties": {
+        "commands": {
+          "additionalProperties": {
+            "items": {
+              "$ref": "#/definitions/ElicitationCommand"
+            },
+            "type": "array"
+          },
+          "default": {},
+          "description": "Map of MCP-server-name patterns to command configurations. Keys are glob patterns matched against the MCP server name (e.g., \"my-server\", \"*\").",
+          "type": "object"
+        }
+      },
+      "type": "object"
+    },
+    "ElicitationResultCommand": {
+      "additionalProperties": false,
+      "description": "Configuration for individual elicitation-result commands with optional messages.",
+      "properties": {
+        "maxOutputLines": {
+          "default": null,
+          "description": "Maximum number of output lines to display (limits both stdout and stderr). Range: 1-10000",
+          "format": "uint32",
+          "maximum": 10000.0,
+          "minimum": 1.0,
+          "type": [
+            "integer",
+            "null"
+          ]
+        },
+        "message": {
+          "default": null,
+          "description": "Custom error message to display when the command fails (exits with non-zero status)",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "notifyPerCommand": {
+          "default": null,
+          "description": "Whether to send individual notifications for this command. Default: false",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "run": {
+          "description": "The shell command to execute. Environment variables are available: CONCLAUDE_MCP_SERVER_NAME, CONCLAUDE_ELICITATION_ACTION, CONCLAUDE_ELICITATION_MODE, CONCLAUDE_ELICITATION_ID, CONCLAUDE_SESSION_ID, CONCLAUDE_TRANSCRIPT_PATH, CONCLAUDE_HOOK_EVENT, CONCLAUDE_CWD, CONCLAUDE_CONFIG_DIR",
+          "type": "string"
+        },
+        "showCommand": {
+          "default": true,
+          "description": "Whether to show the command being executed to the user and Claude. Default: true",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "showStderr": {
+          "default": null,
+          "description": "Whether to show the command's standard error output to the user and Claude. Default: false",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "showStdout": {
+          "default": null,
+          "description": "Whether to show the command's standard output to the user and Claude. Default: false",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "timeout": {
+          "default": null,
+          "description": "Optional command timeout in seconds. Range: 1-3600 (1 second to 1 hour).",
+          "format": "uint64",
+          "maximum": 3600.0,
+          "minimum": 1.0,
+          "type": [
+            "integer",
+            "null"
+          ]
+        }
+      },
+      "required": [
+        "run"
+      ],
+      "type": "object"
+    },
+    "ElicitationResultConfig": {
+      "additionalProperties": false,
+      "description": "Configuration for elicitation-result hooks with MCP-server-based command execution.\n\nCommands run after a user responds to an MCP elicitation. Observational.",
+      "properties": {
+        "commands": {
+          "additionalProperties": {
+            "items": {
+              "$ref": "#/definitions/ElicitationResultCommand"
+            },
+            "type": "array"
+          },
+          "default": {},
+          "description": "Map of MCP-server-name patterns to command configurations. Keys are glob patterns matched against the MCP server name (e.g., \"my-server\", \"*\").",
+          "type": "object"
+        }
+      },
+      "type": "object"
+    },
     "FileChangedCommand": {
       "additionalProperties": false,
       "description": "Configuration for individual file-changed commands with optional messages.",
@@ -410,6 +598,102 @@
           "default": {},
           "description": "Map of memory-type patterns to command configurations. Keys are glob patterns matched against the memory type (e.g., \"User\", \"Project\", \"*\").",
           "type": "object"
+        }
+      },
+      "type": "object"
+    },
+    "MessageDisplayCommand": {
+      "additionalProperties": false,
+      "description": "Configuration for individual message-display commands with optional messages.",
+      "properties": {
+        "maxOutputLines": {
+          "default": null,
+          "description": "Maximum number of output lines to display (limits both stdout and stderr). Range: 1-10000",
+          "format": "uint32",
+          "maximum": 10000.0,
+          "minimum": 1.0,
+          "type": [
+            "integer",
+            "null"
+          ]
+        },
+        "message": {
+          "default": null,
+          "description": "Custom error message to display when the command fails (exits with non-zero status)",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "notifyPerCommand": {
+          "default": null,
+          "description": "Whether to send individual notifications for this command. Default: false",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "run": {
+          "description": "The shell command to execute. Environment variables are available: CONCLAUDE_MESSAGE_ID, CONCLAUDE_TURN_ID, CONCLAUDE_MESSAGE_INDEX, CONCLAUDE_MESSAGE_FINAL, CONCLAUDE_MESSAGE_DELTA, CONCLAUDE_SESSION_ID, CONCLAUDE_TRANSCRIPT_PATH, CONCLAUDE_HOOK_EVENT, CONCLAUDE_CWD, CONCLAUDE_CONFIG_DIR",
+          "type": "string"
+        },
+        "showCommand": {
+          "default": true,
+          "description": "Whether to show the command being executed to the user and Claude. Default: true",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "showStderr": {
+          "default": null,
+          "description": "Whether to show the command's standard error output to the user and Claude. Default: false",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "showStdout": {
+          "default": null,
+          "description": "Whether to show the command's standard output to the user and Claude. Default: false",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "timeout": {
+          "default": null,
+          "description": "Optional command timeout in seconds. Range: 1-3600 (1 second to 1 hour).",
+          "format": "uint64",
+          "maximum": 3600.0,
+          "minimum": 1.0,
+          "type": [
+            "integer",
+            "null"
+          ]
+        }
+      },
+      "required": [
+        "run"
+      ],
+      "type": "object"
+    },
+    "MessageDisplayConfig": {
+      "additionalProperties": false,
+      "description": "Configuration for message-display hooks.\n\n`MessageDisplay` fires per streamed line-batch (potentially many times per message), so by default commands run only on the final flush of each message. Observational.",
+      "properties": {
+        "commands": {
+          "default": [],
+          "description": "Commands to execute on a message-display event. Observational.",
+          "items": {
+            "$ref": "#/definitions/MessageDisplayCommand"
+          },
+          "type": "array"
+        },
+        "onlyFinal": {
+          "default": true,
+          "description": "Run commands only on the final flush of each message (recommended; avoids running per streamed line-batch). Default: true",
+          "type": "boolean"
         }
       },
       "type": "object"
@@ -1402,6 +1686,100 @@
       },
       "type": "object"
     },
+    "TaskCreatedCommand": {
+      "additionalProperties": false,
+      "description": "Configuration for individual task-created commands with optional messages.",
+      "properties": {
+        "maxOutputLines": {
+          "default": null,
+          "description": "Maximum number of output lines to display (limits both stdout and stderr). Range: 1-10000",
+          "format": "uint32",
+          "maximum": 10000.0,
+          "minimum": 1.0,
+          "type": [
+            "integer",
+            "null"
+          ]
+        },
+        "message": {
+          "default": null,
+          "description": "Custom error message to display when the command fails (exits with non-zero status)",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "notifyPerCommand": {
+          "default": null,
+          "description": "Whether to send individual notifications for this command. Default: false",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "run": {
+          "description": "The shell command to execute. Environment variables are available: CONCLAUDE_TASK_ID, CONCLAUDE_TASK_SUBJECT, CONCLAUDE_TASK_DESCRIPTION, CONCLAUDE_SESSION_ID, CONCLAUDE_TRANSCRIPT_PATH, CONCLAUDE_HOOK_EVENT, CONCLAUDE_CWD, CONCLAUDE_CONFIG_DIR",
+          "type": "string"
+        },
+        "showCommand": {
+          "default": true,
+          "description": "Whether to show the command being executed to the user and Claude. Default: true",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "showStderr": {
+          "default": null,
+          "description": "Whether to show the command's standard error output to the user and Claude. Default: false",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "showStdout": {
+          "default": null,
+          "description": "Whether to show the command's standard output to the user and Claude. Default: false",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "timeout": {
+          "default": null,
+          "description": "Optional command timeout in seconds. Range: 1-3600 (1 second to 1 hour).",
+          "format": "uint64",
+          "maximum": 3600.0,
+          "minimum": 1.0,
+          "type": [
+            "integer",
+            "null"
+          ]
+        }
+      },
+      "required": [
+        "run"
+      ],
+      "type": "object"
+    },
+    "TaskCreatedConfig": {
+      "additionalProperties": false,
+      "description": "Configuration for task-created hooks with subject-based command execution.\n\nCommands run when a task is created. Observational.",
+      "properties": {
+        "commands": {
+          "additionalProperties": {
+            "items": {
+              "$ref": "#/definitions/TaskCreatedCommand"
+            },
+            "type": "array"
+          },
+          "default": {},
+          "description": "Map of task-subject patterns to command configurations. Keys are glob patterns matched against the task subject.",
+          "type": "object"
+        }
+      },
+      "type": "object"
+    },
     "TeammateIdleCommand": {
       "additionalProperties": false,
       "description": "Configuration for individual teammate idle commands with optional messages",
@@ -1851,6 +2229,28 @@
       },
       "description": "Configuration for cwd-changed hooks that run when the working directory changes."
     },
+    "elicitation": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/ElicitationConfig"
+        }
+      ],
+      "default": {
+        "commands": {}
+      },
+      "description": "Configuration for elicitation hooks that run when an MCP server requests user input."
+    },
+    "elicitationResult": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/ElicitationResultConfig"
+        }
+      ],
+      "default": {
+        "commands": {}
+      },
+      "description": "Configuration for elicitation-result hooks that run after a user responds to an elicitation."
+    },
     "fileChanged": {
       "allOf": [
         {
@@ -1872,6 +2272,18 @@
         "commands": {}
       },
       "description": "Configuration for instructions-loaded hooks that run when an instructions/memory file loads."
+    },
+    "messageDisplay": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/MessageDisplayConfig"
+        }
+      ],
+      "default": {
+        "commands": [],
+        "onlyFinal": false
+      },
+      "description": "Configuration for message-display hooks that run as assistant messages stream."
     },
     "notifications": {
       "allOf": [
@@ -2011,6 +2423,17 @@
         "commands": {}
       },
       "description": "Configuration for task completed hooks"
+    },
+    "taskCreated": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/TaskCreatedConfig"
+        }
+      ],
+      "default": {
+        "commands": {}
+      },
+      "description": "Configuration for task-created hooks that run when a task is created."
     },
     "teammateIdle": {
       "allOf": [

--- a/docs/src/content/docs/reference/config/configuration.md
+++ b/docs/src/content/docs/reference/config/configuration.md
@@ -15,8 +15,11 @@ Conclaude uses YAML configuration files to define lifecycle hooks, file protecti
 |---------|-------------|-------------|
 | [Config Change](/conclaude/reference/config/config-change) | Configuration for config change hooks with source-based command execution | `commands` |
 | [Cwd Changed](/conclaude/reference/config/cwd-changed) | Configuration for cwd-changed hooks with path-based command execution | `commands` |
+| [Elicitation](/conclaude/reference/config/elicitation) | Configuration for elicitation hooks with MCP-server-based command execution | `commands` |
+| [Elicitation Result](/conclaude/reference/config/elicitation-result) | Configuration for elicitation-result hooks with MCP-server-based command execution | `commands` |
 | [File Changed](/conclaude/reference/config/file-changed) | Configuration for file-changed hooks with path-based command execution | `commands` |
 | [Instructions Loaded](/conclaude/reference/config/instructions-loaded) | Configuration for instructions-loaded hooks with command execution | `commands` |
+| [Message Display](/conclaude/reference/config/message-display) | Configuration for message-display hooks | `commands`, `onlyFinal` |
 | [Notifications](/conclaude/reference/config/notifications) | Configuration for system notifications | `enabled`, `hooks`, `showErrors` |
 | [Permission Denied](/conclaude/reference/config/permission-denied) | Configuration for permission-denied hooks with tool-based command execution | `commands` |
 | [Permission Request](/conclaude/reference/config/permission-request) | Configuration for permission request hooks that control tool permission decisions | `allow`, `default`, `deny` |
@@ -29,6 +32,7 @@ Conclaude uses YAML configuration files to define lifecycle hooks, file protecti
 | [Stop Failure](/conclaude/reference/config/stop-failure) | Configuration for stop failure hook commands that run when a turn ends due to an API error | `commands` |
 | [Subagent Stop](/conclaude/reference/config/subagent-stop) | Configuration for subagent stop hooks with pattern-based command execution | `commands` |
 | [Task Completed](/conclaude/reference/config/task-completed) | Configuration for task completed hooks with pattern-based command execution | `commands` |
+| [Task Created](/conclaude/reference/config/task-created) | Configuration for task-created hooks with subject-based command execution | `commands` |
 | [Teammate Idle](/conclaude/reference/config/teammate-idle) | Configuration for teammate idle hooks with pattern-based command execution | `commands` |
 | [User Prompt Expansion](/conclaude/reference/config/user-prompt-expansion) | Configuration for user-prompt-expansion hooks with command-name-based command execution | `commands` |
 | [User Prompt Submit](/conclaude/reference/config/user-prompt-submit) | Configuration for user prompt submit hook with context injection rules and command execution | `commands`, `contextRules`, `slashCommands` |
@@ -46,6 +50,14 @@ Configuration for config change hooks with source-based command execution.
 
 Configuration for cwd-changed hooks with path-based command execution.
 
+### [Elicitation](/conclaude/reference/config/elicitation)
+
+Configuration for elicitation hooks with MCP-server-based command execution.
+
+### [Elicitation Result](/conclaude/reference/config/elicitation-result)
+
+Configuration for elicitation-result hooks with MCP-server-based command execution.
+
 ### [File Changed](/conclaude/reference/config/file-changed)
 
 Configuration for file-changed hooks with path-based command execution.
@@ -53,6 +65,10 @@ Configuration for file-changed hooks with path-based command execution.
 ### [Instructions Loaded](/conclaude/reference/config/instructions-loaded)
 
 Configuration for instructions-loaded hooks with command execution.
+
+### [Message Display](/conclaude/reference/config/message-display)
+
+Configuration for message-display hooks.
 
 ### [Notifications](/conclaude/reference/config/notifications)
 
@@ -101,6 +117,10 @@ Configuration for subagent stop hooks with pattern-based command execution.
 ### [Task Completed](/conclaude/reference/config/task-completed)
 
 Configuration for task completed hooks with pattern-based command execution.
+
+### [Task Created](/conclaude/reference/config/task-created)
+
+Configuration for task-created hooks with subject-based command execution.
 
 ### [Teammate Idle](/conclaude/reference/config/teammate-idle)
 

--- a/docs/src/content/docs/reference/config/elicitation-result.md
+++ b/docs/src/content/docs/reference/config/elicitation-result.md
@@ -1,0 +1,46 @@
+---
+title: Elicitation Result
+description: Configuration options for elicitationResult
+---
+
+# Elicitation Result
+
+Configuration for elicitation-result hooks with MCP-server-based command execution.
+
+Commands run after a user responds to an MCP elicitation. Observational.
+
+## Configuration Properties
+
+### `commands`
+
+Map of MCP-server-name patterns to command configurations. Keys are glob patterns matched against the MCP server name (e.g., "my-server", "*").
+
+| Attribute | Value |
+|-----------|-------|
+| **Type** | `object` |
+| **Default** | `{}` |
+
+## Nested Types
+
+This section uses the following nested type definitions:
+
+### `ElicitationResultCommand` Type
+
+Configuration for individual elicitation-result commands with optional messages.
+
+**Properties:**
+
+| Property | Type | Default | Description |
+|----------|------|---------|-------------|
+| `maxOutputLines` | `integer | null` | `null` | Maximum number of output lines to display (limits both stdout and stderr) |
+| `message` | `string | null` | `null` | Custom error message to display when the command fails (exits with non-zero status) |
+| `notifyPerCommand` | `boolean | null` | `null` | Whether to send individual notifications for this command |
+| `run` | `string` | - | The shell command to execute |
+| `showCommand` | `boolean | null` | `true` | Whether to show the command being executed to the user and Claude |
+| `showStderr` | `boolean | null` | `null` | Whether to show the command's standard error output to the user and Claude |
+| `showStdout` | `boolean | null` | `null` | Whether to show the command's standard output to the user and Claude |
+| `timeout` | `integer | null` | `null` | Optional command timeout in seconds |
+
+## See Also
+
+- [Configuration Overview](/conclaude/reference/config/configuration) - Complete reference for all configuration options

--- a/docs/src/content/docs/reference/config/elicitation.md
+++ b/docs/src/content/docs/reference/config/elicitation.md
@@ -1,0 +1,46 @@
+---
+title: Elicitation
+description: Configuration options for elicitation
+---
+
+# Elicitation
+
+Configuration for elicitation hooks with MCP-server-based command execution.
+
+Commands run when an MCP server requests user input. Observational.
+
+## Configuration Properties
+
+### `commands`
+
+Map of MCP-server-name patterns to command configurations. Keys are glob patterns matched against the MCP server name (e.g., "my-server", "*").
+
+| Attribute | Value |
+|-----------|-------|
+| **Type** | `object` |
+| **Default** | `{}` |
+
+## Nested Types
+
+This section uses the following nested type definitions:
+
+### `ElicitationCommand` Type
+
+Configuration for individual elicitation commands with optional messages.
+
+**Properties:**
+
+| Property | Type | Default | Description |
+|----------|------|---------|-------------|
+| `maxOutputLines` | `integer | null` | `null` | Maximum number of output lines to display (limits both stdout and stderr) |
+| `message` | `string | null` | `null` | Custom error message to display when the command fails (exits with non-zero status) |
+| `notifyPerCommand` | `boolean | null` | `null` | Whether to send individual notifications for this command |
+| `run` | `string` | - | The shell command to execute |
+| `showCommand` | `boolean | null` | `true` | Whether to show the command being executed to the user and Claude |
+| `showStderr` | `boolean | null` | `null` | Whether to show the command's standard error output to the user and Claude |
+| `showStdout` | `boolean | null` | `null` | Whether to show the command's standard output to the user and Claude |
+| `timeout` | `integer | null` | `null` | Optional command timeout in seconds |
+
+## See Also
+
+- [Configuration Overview](/conclaude/reference/config/configuration) - Complete reference for all configuration options

--- a/docs/src/content/docs/reference/config/message-display.md
+++ b/docs/src/content/docs/reference/config/message-display.md
@@ -1,0 +1,55 @@
+---
+title: Message Display
+description: Configuration options for messageDisplay
+---
+
+# Message Display
+
+Configuration for message-display hooks.
+
+`MessageDisplay` fires per streamed line-batch (potentially many times per message), so by default commands run only on the final flush of each message. Observational.
+
+## Configuration Properties
+
+### `commands`
+
+Commands to execute on a message-display event. Observational.
+
+| Attribute | Value |
+|-----------|-------|
+| **Type** | `array` |
+| **Default** | `[]` |
+
+### `onlyFinal`
+
+Run commands only on the final flush of each message (recommended; avoids running per streamed line-batch). Default: true
+
+| Attribute | Value |
+|-----------|-------|
+| **Type** | `boolean` |
+| **Default** | `true` |
+
+## Nested Types
+
+This section uses the following nested type definitions:
+
+### `MessageDisplayCommand` Type
+
+Configuration for individual message-display commands with optional messages.
+
+**Properties:**
+
+| Property | Type | Default | Description |
+|----------|------|---------|-------------|
+| `maxOutputLines` | `integer | null` | `null` | Maximum number of output lines to display (limits both stdout and stderr) |
+| `message` | `string | null` | `null` | Custom error message to display when the command fails (exits with non-zero status) |
+| `notifyPerCommand` | `boolean | null` | `null` | Whether to send individual notifications for this command |
+| `run` | `string` | - | The shell command to execute |
+| `showCommand` | `boolean | null` | `true` | Whether to show the command being executed to the user and Claude |
+| `showStderr` | `boolean | null` | `null` | Whether to show the command's standard error output to the user and Claude |
+| `showStdout` | `boolean | null` | `null` | Whether to show the command's standard output to the user and Claude |
+| `timeout` | `integer | null` | `null` | Optional command timeout in seconds |
+
+## See Also
+
+- [Configuration Overview](/conclaude/reference/config/configuration) - Complete reference for all configuration options

--- a/docs/src/content/docs/reference/config/task-created.md
+++ b/docs/src/content/docs/reference/config/task-created.md
@@ -1,0 +1,46 @@
+---
+title: Task Created
+description: Configuration options for taskCreated
+---
+
+# Task Created
+
+Configuration for task-created hooks with subject-based command execution.
+
+Commands run when a task is created. Observational.
+
+## Configuration Properties
+
+### `commands`
+
+Map of task-subject patterns to command configurations. Keys are glob patterns matched against the task subject.
+
+| Attribute | Value |
+|-----------|-------|
+| **Type** | `object` |
+| **Default** | `{}` |
+
+## Nested Types
+
+This section uses the following nested type definitions:
+
+### `TaskCreatedCommand` Type
+
+Configuration for individual task-created commands with optional messages.
+
+**Properties:**
+
+| Property | Type | Default | Description |
+|----------|------|---------|-------------|
+| `maxOutputLines` | `integer | null` | `null` | Maximum number of output lines to display (limits both stdout and stderr) |
+| `message` | `string | null` | `null` | Custom error message to display when the command fails (exits with non-zero status) |
+| `notifyPerCommand` | `boolean | null` | `null` | Whether to send individual notifications for this command |
+| `run` | `string` | - | The shell command to execute |
+| `showCommand` | `boolean | null` | `true` | Whether to show the command being executed to the user and Claude |
+| `showStderr` | `boolean | null` | `null` | Whether to show the command's standard error output to the user and Claude |
+| `showStdout` | `boolean | null` | `null` | Whether to show the command's standard output to the user and Claude |
+| `timeout` | `integer | null` | `null` | Optional command timeout in seconds |
+
+## See Also
+
+- [Configuration Overview](/conclaude/reference/config/configuration) - Complete reference for all configuration options

--- a/src/config.rs
+++ b/src/config.rs
@@ -826,6 +826,183 @@ pub struct UserPromptExpansionConfig {
     pub commands: std::collections::HashMap<String, Vec<UserPromptExpansionCommand>>,
 }
 
+/// Configuration for individual task-created commands with optional messages.
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, FieldList)]
+#[serde(deny_unknown_fields)]
+pub struct TaskCreatedCommand {
+    /// The shell command to execute. Environment variables are available: CONCLAUDE_TASK_ID, CONCLAUDE_TASK_SUBJECT, CONCLAUDE_TASK_DESCRIPTION, CONCLAUDE_SESSION_ID, CONCLAUDE_TRANSCRIPT_PATH, CONCLAUDE_HOOK_EVENT, CONCLAUDE_CWD, CONCLAUDE_CONFIG_DIR
+    pub run: String,
+    /// Custom error message to display when the command fails (exits with non-zero status)
+    #[serde(default)]
+    pub message: Option<String>,
+    /// Whether to show the command being executed to the user and Claude. Default: true
+    #[serde(default = "default_option_true", rename = "showCommand")]
+    pub show_command: Option<bool>,
+    /// Whether to show the command's standard output to the user and Claude. Default: false
+    #[serde(default, rename = "showStdout")]
+    pub show_stdout: Option<bool>,
+    /// Whether to show the command's standard error output to the user and Claude. Default: false
+    #[serde(default, rename = "showStderr")]
+    pub show_stderr: Option<bool>,
+    /// Maximum number of output lines to display (limits both stdout and stderr). Range: 1-10000
+    #[serde(default, rename = "maxOutputLines")]
+    #[schemars(range(min = 1, max = 10000))]
+    pub max_output_lines: Option<u32>,
+    /// Optional command timeout in seconds. Range: 1-3600 (1 second to 1 hour).
+    #[serde(default)]
+    #[schemars(range(min = 1, max = 3600))]
+    pub timeout: Option<u64>,
+    /// Whether to send individual notifications for this command. Default: false
+    #[serde(default, rename = "notifyPerCommand")]
+    pub notify_per_command: Option<bool>,
+}
+
+/// Configuration for individual elicitation commands with optional messages.
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, FieldList)]
+#[serde(deny_unknown_fields)]
+pub struct ElicitationCommand {
+    /// The shell command to execute. Environment variables are available: CONCLAUDE_MCP_SERVER_NAME, CONCLAUDE_ELICITATION_MESSAGE, CONCLAUDE_ELICITATION_MODE, CONCLAUDE_ELICITATION_ID, CONCLAUDE_SESSION_ID, CONCLAUDE_TRANSCRIPT_PATH, CONCLAUDE_HOOK_EVENT, CONCLAUDE_CWD, CONCLAUDE_CONFIG_DIR
+    pub run: String,
+    /// Custom error message to display when the command fails (exits with non-zero status)
+    #[serde(default)]
+    pub message: Option<String>,
+    /// Whether to show the command being executed to the user and Claude. Default: true
+    #[serde(default = "default_option_true", rename = "showCommand")]
+    pub show_command: Option<bool>,
+    /// Whether to show the command's standard output to the user and Claude. Default: false
+    #[serde(default, rename = "showStdout")]
+    pub show_stdout: Option<bool>,
+    /// Whether to show the command's standard error output to the user and Claude. Default: false
+    #[serde(default, rename = "showStderr")]
+    pub show_stderr: Option<bool>,
+    /// Maximum number of output lines to display (limits both stdout and stderr). Range: 1-10000
+    #[serde(default, rename = "maxOutputLines")]
+    #[schemars(range(min = 1, max = 10000))]
+    pub max_output_lines: Option<u32>,
+    /// Optional command timeout in seconds. Range: 1-3600 (1 second to 1 hour).
+    #[serde(default)]
+    #[schemars(range(min = 1, max = 3600))]
+    pub timeout: Option<u64>,
+    /// Whether to send individual notifications for this command. Default: false
+    #[serde(default, rename = "notifyPerCommand")]
+    pub notify_per_command: Option<bool>,
+}
+
+/// Configuration for individual elicitation-result commands with optional messages.
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, FieldList)]
+#[serde(deny_unknown_fields)]
+pub struct ElicitationResultCommand {
+    /// The shell command to execute. Environment variables are available: CONCLAUDE_MCP_SERVER_NAME, CONCLAUDE_ELICITATION_ACTION, CONCLAUDE_ELICITATION_MODE, CONCLAUDE_ELICITATION_ID, CONCLAUDE_SESSION_ID, CONCLAUDE_TRANSCRIPT_PATH, CONCLAUDE_HOOK_EVENT, CONCLAUDE_CWD, CONCLAUDE_CONFIG_DIR
+    pub run: String,
+    /// Custom error message to display when the command fails (exits with non-zero status)
+    #[serde(default)]
+    pub message: Option<String>,
+    /// Whether to show the command being executed to the user and Claude. Default: true
+    #[serde(default = "default_option_true", rename = "showCommand")]
+    pub show_command: Option<bool>,
+    /// Whether to show the command's standard output to the user and Claude. Default: false
+    #[serde(default, rename = "showStdout")]
+    pub show_stdout: Option<bool>,
+    /// Whether to show the command's standard error output to the user and Claude. Default: false
+    #[serde(default, rename = "showStderr")]
+    pub show_stderr: Option<bool>,
+    /// Maximum number of output lines to display (limits both stdout and stderr). Range: 1-10000
+    #[serde(default, rename = "maxOutputLines")]
+    #[schemars(range(min = 1, max = 10000))]
+    pub max_output_lines: Option<u32>,
+    /// Optional command timeout in seconds. Range: 1-3600 (1 second to 1 hour).
+    #[serde(default)]
+    #[schemars(range(min = 1, max = 3600))]
+    pub timeout: Option<u64>,
+    /// Whether to send individual notifications for this command. Default: false
+    #[serde(default, rename = "notifyPerCommand")]
+    pub notify_per_command: Option<bool>,
+}
+
+/// Configuration for individual message-display commands with optional messages.
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, FieldList)]
+#[serde(deny_unknown_fields)]
+pub struct MessageDisplayCommand {
+    /// The shell command to execute. Environment variables are available: CONCLAUDE_MESSAGE_ID, CONCLAUDE_TURN_ID, CONCLAUDE_MESSAGE_INDEX, CONCLAUDE_MESSAGE_FINAL, CONCLAUDE_MESSAGE_DELTA, CONCLAUDE_SESSION_ID, CONCLAUDE_TRANSCRIPT_PATH, CONCLAUDE_HOOK_EVENT, CONCLAUDE_CWD, CONCLAUDE_CONFIG_DIR
+    pub run: String,
+    /// Custom error message to display when the command fails (exits with non-zero status)
+    #[serde(default)]
+    pub message: Option<String>,
+    /// Whether to show the command being executed to the user and Claude. Default: true
+    #[serde(default = "default_option_true", rename = "showCommand")]
+    pub show_command: Option<bool>,
+    /// Whether to show the command's standard output to the user and Claude. Default: false
+    #[serde(default, rename = "showStdout")]
+    pub show_stdout: Option<bool>,
+    /// Whether to show the command's standard error output to the user and Claude. Default: false
+    #[serde(default, rename = "showStderr")]
+    pub show_stderr: Option<bool>,
+    /// Maximum number of output lines to display (limits both stdout and stderr). Range: 1-10000
+    #[serde(default, rename = "maxOutputLines")]
+    #[schemars(range(min = 1, max = 10000))]
+    pub max_output_lines: Option<u32>,
+    /// Optional command timeout in seconds. Range: 1-3600 (1 second to 1 hour).
+    #[serde(default)]
+    #[schemars(range(min = 1, max = 3600))]
+    pub timeout: Option<u64>,
+    /// Whether to send individual notifications for this command. Default: false
+    #[serde(default, rename = "notifyPerCommand")]
+    pub notify_per_command: Option<bool>,
+}
+
+/// Configuration for task-created hooks with subject-based command execution.
+///
+/// Commands run when a task is created. Observational.
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, Default, FieldList)]
+#[serde(deny_unknown_fields)]
+pub struct TaskCreatedConfig {
+    /// Map of task-subject patterns to command configurations.
+    /// Keys are glob patterns matched against the task subject.
+    #[serde(default)]
+    pub commands: std::collections::HashMap<String, Vec<TaskCreatedCommand>>,
+}
+
+/// Configuration for elicitation hooks with MCP-server-based command execution.
+///
+/// Commands run when an MCP server requests user input. Observational.
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, Default, FieldList)]
+#[serde(deny_unknown_fields)]
+pub struct ElicitationConfig {
+    /// Map of MCP-server-name patterns to command configurations.
+    /// Keys are glob patterns matched against the MCP server name (e.g., "my-server", "*").
+    #[serde(default)]
+    pub commands: std::collections::HashMap<String, Vec<ElicitationCommand>>,
+}
+
+/// Configuration for elicitation-result hooks with MCP-server-based command execution.
+///
+/// Commands run after a user responds to an MCP elicitation. Observational.
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, Default, FieldList)]
+#[serde(deny_unknown_fields)]
+pub struct ElicitationResultConfig {
+    /// Map of MCP-server-name patterns to command configurations.
+    /// Keys are glob patterns matched against the MCP server name (e.g., "my-server", "*").
+    #[serde(default)]
+    pub commands: std::collections::HashMap<String, Vec<ElicitationResultCommand>>,
+}
+
+/// Configuration for message-display hooks.
+///
+/// `MessageDisplay` fires per streamed line-batch (potentially many times per
+/// message), so by default commands run only on the final flush of each message.
+/// Observational.
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, Default, FieldList)]
+#[serde(deny_unknown_fields)]
+pub struct MessageDisplayConfig {
+    /// Commands to execute on a message-display event. Observational.
+    #[serde(default)]
+    pub commands: Vec<MessageDisplayCommand>,
+    /// Run commands only on the final flush of each message (recommended; avoids
+    /// running per streamed line-batch). Default: true
+    #[serde(default = "default_true", rename = "onlyFinal")]
+    pub only_final: bool,
+}
+
 /// Configuration for stop hook commands that run when Claude is about to stop
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, Default, FieldList)]
 #[serde(deny_unknown_fields)]
@@ -1662,6 +1839,18 @@ pub struct ConclaudeConfig {
     /// Configuration for user-prompt-expansion hooks that run when a command/prompt expands.
     #[serde(default, rename = "userPromptExpansion")]
     pub user_prompt_expansion: UserPromptExpansionConfig,
+    /// Configuration for task-created hooks that run when a task is created.
+    #[serde(default, rename = "taskCreated")]
+    pub task_created: TaskCreatedConfig,
+    /// Configuration for elicitation hooks that run when an MCP server requests user input.
+    #[serde(default)]
+    pub elicitation: ElicitationConfig,
+    /// Configuration for elicitation-result hooks that run after a user responds to an elicitation.
+    #[serde(default, rename = "elicitationResult")]
+    pub elicitation_result: ElicitationResultConfig,
+    /// Configuration for message-display hooks that run as assistant messages stream.
+    #[serde(default, rename = "messageDisplay")]
+    pub message_display: MessageDisplayConfig,
 }
 
 /// Extract the field name from an unknown field error message

--- a/src/hooks.rs
+++ b/src/hooks.rs
@@ -1,25 +1,28 @@
 use crate::config::{
     extract_bash_commands, load_conclaude_config, ConclaudeConfig, ConfigChangeConfig,
-    CwdChangedConfig, FileChangedConfig, InstructionsLoadedConfig, PermissionDeniedConfig,
-    PostCompactConfig, PostToolBatchConfig, SetupConfig, SkillStartConfig, SlashCommandConfig,
-    SubagentStopConfig, TaskCompletedConfig, TeammateIdleConfig, UserPromptExpansionConfig,
+    CwdChangedConfig, ElicitationConfig, ElicitationResultConfig, FileChangedConfig,
+    InstructionsLoadedConfig, MessageDisplayConfig, PermissionDeniedConfig, PostCompactConfig,
+    PostToolBatchConfig, SetupConfig, SkillStartConfig, SlashCommandConfig, SubagentStopConfig,
+    TaskCompletedConfig, TaskCreatedConfig, TeammateIdleConfig, UserPromptExpansionConfig,
     UserPromptSubmitCommand,
 };
 use crate::gitignore::{find_git_root, is_path_git_ignored};
 use crate::types::{
-    validate_base_payload, validate_cwd_changed_payload, validate_file_changed_payload,
-    validate_instructions_loaded_payload, validate_permission_denied_payload,
-    validate_permission_request_payload, validate_post_compact_payload,
-    validate_post_tool_batch_payload, validate_setup_payload, validate_stop_failure_payload,
-    validate_subagent_start_payload, validate_subagent_stop_payload,
-    validate_task_completed_payload, validate_teammate_idle_payload,
+    validate_base_payload, validate_cwd_changed_payload, validate_elicitation_payload,
+    validate_elicitation_result_payload, validate_file_changed_payload,
+    validate_instructions_loaded_payload, validate_message_display_payload,
+    validate_permission_denied_payload, validate_permission_request_payload,
+    validate_post_compact_payload, validate_post_tool_batch_payload, validate_setup_payload,
+    validate_stop_failure_payload, validate_subagent_start_payload, validate_subagent_stop_payload,
+    validate_task_completed_payload, validate_task_created_payload, validate_teammate_idle_payload,
     validate_user_prompt_expansion_payload, validate_worktree_create_payload,
     validate_worktree_remove_payload, ConfigChangePayload, ConfigChangeSource, CwdChangedPayload,
-    FileChangedPayload, HookResult, InstructionsLoadedPayload, NotificationPayload,
-    PermissionDeniedPayload, PermissionRequestPayload, PostCompactPayload, PostToolBatchPayload,
-    PostToolUseFailurePayload, PostToolUsePayload, PreCompactPayload, PreToolUsePayload,
-    SessionEndPayload, SessionStartPayload, SetupPayload, StopFailurePayload, StopPayload,
-    SubagentStartPayload, SubagentStopPayload, TaskCompletedPayload, TeammateIdlePayload,
+    ElicitationPayload, ElicitationResultPayload, FileChangedPayload, HookResult,
+    InstructionsLoadedPayload, MessageDisplayPayload, NotificationPayload, PermissionDeniedPayload,
+    PermissionRequestPayload, PostCompactPayload, PostToolBatchPayload, PostToolUseFailurePayload,
+    PostToolUsePayload, PreCompactPayload, PreToolUsePayload, SessionEndPayload,
+    SessionStartPayload, SetupPayload, StopFailurePayload, StopPayload, SubagentStartPayload,
+    SubagentStopPayload, TaskCompletedPayload, TaskCreatedPayload, TeammateIdlePayload,
     UserPromptExpansionPayload, UserPromptSubmitPayload, WorktreeCreatePayload, WorktreeRemovePayload,
 };
 use anyhow::{Context, Result};
@@ -214,6 +217,10 @@ pub(crate) fn is_system_event_hook(hook_name: &str) -> bool {
             | "PostToolBatch"
             | "PermissionDenied"
             | "UserPromptExpansion"
+            | "TaskCreated"
+            | "Elicitation"
+            | "ElicitationResult"
+            | "MessageDisplay"
     )
 }
 
@@ -5070,6 +5077,369 @@ pub async fn handle_user_prompt_expansion() -> Result<HookResult> {
                 )
                 .await;
             }
+        }
+    }
+
+    Ok(HookResult::success())
+}
+
+/// Collect commands from `TaskCreatedConfig` for matching patterns.
+fn collect_task_created_commands(
+    config: &TaskCreatedConfig,
+    matching_patterns: &[&str],
+) -> Result<Vec<GenericCommandConfig>> {
+    let mut commands = Vec::new();
+    for pattern in matching_patterns {
+        if let Some(cmd_list) = config.commands.get(*pattern) {
+            for cmd_config in cmd_list {
+                for cmd in extract_bash_commands(&cmd_config.run)? {
+                    commands.push(GenericCommandConfig {
+                        command: cmd,
+                        message: cmd_config.message.clone(),
+                        show_stdout: cmd_config.show_stdout.unwrap_or(false),
+                        show_stderr: cmd_config.show_stderr.unwrap_or(false),
+                        max_output_lines: cmd_config.max_output_lines,
+                        timeout: cmd_config.timeout,
+                        show_command: cmd_config.show_command.unwrap_or(true),
+                        notify_per_command: cmd_config.notify_per_command.unwrap_or(false),
+                    });
+                }
+            }
+        }
+    }
+    Ok(commands)
+}
+
+/// Collect commands from `ElicitationConfig` for matching patterns.
+fn collect_elicitation_commands(
+    config: &ElicitationConfig,
+    matching_patterns: &[&str],
+) -> Result<Vec<GenericCommandConfig>> {
+    let mut commands = Vec::new();
+    for pattern in matching_patterns {
+        if let Some(cmd_list) = config.commands.get(*pattern) {
+            for cmd_config in cmd_list {
+                for cmd in extract_bash_commands(&cmd_config.run)? {
+                    commands.push(GenericCommandConfig {
+                        command: cmd,
+                        message: cmd_config.message.clone(),
+                        show_stdout: cmd_config.show_stdout.unwrap_or(false),
+                        show_stderr: cmd_config.show_stderr.unwrap_or(false),
+                        max_output_lines: cmd_config.max_output_lines,
+                        timeout: cmd_config.timeout,
+                        show_command: cmd_config.show_command.unwrap_or(true),
+                        notify_per_command: cmd_config.notify_per_command.unwrap_or(false),
+                    });
+                }
+            }
+        }
+    }
+    Ok(commands)
+}
+
+/// Collect commands from `ElicitationResultConfig` for matching patterns.
+fn collect_elicitation_result_commands(
+    config: &ElicitationResultConfig,
+    matching_patterns: &[&str],
+) -> Result<Vec<GenericCommandConfig>> {
+    let mut commands = Vec::new();
+    for pattern in matching_patterns {
+        if let Some(cmd_list) = config.commands.get(*pattern) {
+            for cmd_config in cmd_list {
+                for cmd in extract_bash_commands(&cmd_config.run)? {
+                    commands.push(GenericCommandConfig {
+                        command: cmd,
+                        message: cmd_config.message.clone(),
+                        show_stdout: cmd_config.show_stdout.unwrap_or(false),
+                        show_stderr: cmd_config.show_stderr.unwrap_or(false),
+                        max_output_lines: cmd_config.max_output_lines,
+                        timeout: cmd_config.timeout,
+                        show_command: cmd_config.show_command.unwrap_or(true),
+                        notify_per_command: cmd_config.notify_per_command.unwrap_or(false),
+                    });
+                }
+            }
+        }
+    }
+    Ok(commands)
+}
+
+/// Collect commands from `MessageDisplayConfig` (flat command list).
+fn collect_message_display_commands(
+    config: &MessageDisplayConfig,
+) -> Result<Vec<GenericCommandConfig>> {
+    let mut commands = Vec::new();
+    for cmd_config in &config.commands {
+        for cmd in extract_bash_commands(&cmd_config.run)? {
+            commands.push(GenericCommandConfig {
+                command: cmd,
+                message: cmd_config.message.clone(),
+                show_stdout: cmd_config.show_stdout.unwrap_or(false),
+                show_stderr: cmd_config.show_stderr.unwrap_or(false),
+                max_output_lines: cmd_config.max_output_lines,
+                timeout: cmd_config.timeout,
+                show_command: cmd_config.show_command.unwrap_or(true),
+                notify_per_command: cmd_config.notify_per_command.unwrap_or(false),
+            });
+        }
+    }
+    Ok(commands)
+}
+
+/// Handles `TaskCreated` hook events fired when a task is created. Observational.
+///
+/// # Errors
+///
+/// Returns an error if payload reading or validation fails.
+pub async fn handle_task_created() -> Result<HookResult> {
+    let payload: TaskCreatedPayload = read_payload_from_stdin()?;
+    validate_task_created_payload(&payload).map_err(|e| anyhow::anyhow!(e))?;
+
+    println!(
+        "Processing TaskCreated hook: session_id={}, task_id={}, task_subject={}",
+        payload.base.session_id, payload.task_id, payload.task_subject
+    );
+
+    let agent_name = std::env::var(AGENT_ENV_VAR).ok();
+    if let Some(ref name) = agent_name {
+        std::env::set_var("CONCLAUDE_AGENT_NAME", name);
+    }
+    std::env::set_var("CONCLAUDE_TASK_ID", &payload.task_id);
+    std::env::set_var("CONCLAUDE_TASK_SUBJECT", &payload.task_subject);
+    std::env::set_var(
+        "CONCLAUDE_TASK_DESCRIPTION",
+        payload.task_description.as_deref().unwrap_or(""),
+    );
+
+    let (config, config_path) = get_config().await?;
+    let config_dir = get_config_dir(config_path);
+
+    if !config.task_created.commands.is_empty() {
+        let matching_patterns =
+            match_generic_patterns(&payload.task_subject, &config.task_created.commands)?;
+        if !matching_patterns.is_empty() {
+            let commands = collect_task_created_commands(&config.task_created, &matching_patterns)?;
+            if !commands.is_empty() {
+                let mut env_vars = HashMap::new();
+                env_vars.insert("CONCLAUDE_TASK_ID".to_string(), payload.task_id.clone());
+                env_vars.insert(
+                    "CONCLAUDE_TASK_SUBJECT".to_string(),
+                    payload.task_subject.clone(),
+                );
+                env_vars.insert(
+                    "CONCLAUDE_TASK_DESCRIPTION".to_string(),
+                    payload.task_description.clone().unwrap_or_default(),
+                );
+                insert_base_env_vars(
+                    &mut env_vars,
+                    &payload.base,
+                    &payload,
+                    "TaskCreated",
+                    config_dir,
+                );
+                let _ =
+                    execute_generic_commands(&commands, &env_vars, config_dir, "TaskCreated").await;
+            }
+        }
+    }
+
+    send_notification(
+        "TaskCreated",
+        "success",
+        Some(&format!("Task '{}' created", payload.task_subject)),
+    );
+    Ok(HookResult::success())
+}
+
+/// Handles `Elicitation` hook events fired when an MCP server requests user input.
+/// Observational.
+///
+/// # Errors
+///
+/// Returns an error if payload reading or validation fails.
+pub async fn handle_elicitation() -> Result<HookResult> {
+    let payload: ElicitationPayload = read_payload_from_stdin()?;
+    validate_elicitation_payload(&payload).map_err(|e| anyhow::anyhow!(e))?;
+
+    let mode_str = payload.mode.as_ref().map(ToString::to_string).unwrap_or_default();
+    println!(
+        "Processing Elicitation hook: session_id={}, mcp_server_name={}, mode={}",
+        payload.base.session_id, payload.mcp_server_name, mode_str
+    );
+
+    let agent_name = std::env::var(AGENT_ENV_VAR).ok();
+    if let Some(ref name) = agent_name {
+        std::env::set_var("CONCLAUDE_AGENT_NAME", name);
+    }
+    std::env::set_var("CONCLAUDE_MCP_SERVER_NAME", &payload.mcp_server_name);
+    std::env::set_var("CONCLAUDE_ELICITATION_MESSAGE", &payload.message);
+    std::env::set_var("CONCLAUDE_ELICITATION_MODE", &mode_str);
+    std::env::set_var(
+        "CONCLAUDE_ELICITATION_ID",
+        payload.elicitation_id.as_deref().unwrap_or(""),
+    );
+
+    let (config, config_path) = get_config().await?;
+    let config_dir = get_config_dir(config_path);
+
+    if !config.elicitation.commands.is_empty() {
+        let matching_patterns =
+            match_generic_patterns(&payload.mcp_server_name, &config.elicitation.commands)?;
+        if !matching_patterns.is_empty() {
+            let commands = collect_elicitation_commands(&config.elicitation, &matching_patterns)?;
+            if !commands.is_empty() {
+                let mut env_vars = HashMap::new();
+                env_vars.insert(
+                    "CONCLAUDE_MCP_SERVER_NAME".to_string(),
+                    payload.mcp_server_name.clone(),
+                );
+                env_vars.insert(
+                    "CONCLAUDE_ELICITATION_MESSAGE".to_string(),
+                    payload.message.clone(),
+                );
+                env_vars.insert("CONCLAUDE_ELICITATION_MODE".to_string(), mode_str.clone());
+                env_vars.insert(
+                    "CONCLAUDE_ELICITATION_ID".to_string(),
+                    payload.elicitation_id.clone().unwrap_or_default(),
+                );
+                insert_base_env_vars(
+                    &mut env_vars,
+                    &payload.base,
+                    &payload,
+                    "Elicitation",
+                    config_dir,
+                );
+                let _ =
+                    execute_generic_commands(&commands, &env_vars, config_dir, "Elicitation").await;
+            }
+        }
+    }
+
+    Ok(HookResult::success())
+}
+
+/// Handles `ElicitationResult` hook events fired after a user responds to an MCP elicitation.
+/// Observational.
+///
+/// # Errors
+///
+/// Returns an error if payload reading or validation fails.
+pub async fn handle_elicitation_result() -> Result<HookResult> {
+    let payload: ElicitationResultPayload = read_payload_from_stdin()?;
+    validate_elicitation_result_payload(&payload).map_err(|e| anyhow::anyhow!(e))?;
+
+    let action_str = payload.action.to_string();
+    let mode_str = payload.mode.as_ref().map(ToString::to_string).unwrap_or_default();
+    println!(
+        "Processing ElicitationResult hook: session_id={}, mcp_server_name={}, action={}",
+        payload.base.session_id, payload.mcp_server_name, action_str
+    );
+
+    let agent_name = std::env::var(AGENT_ENV_VAR).ok();
+    if let Some(ref name) = agent_name {
+        std::env::set_var("CONCLAUDE_AGENT_NAME", name);
+    }
+    std::env::set_var("CONCLAUDE_MCP_SERVER_NAME", &payload.mcp_server_name);
+    std::env::set_var("CONCLAUDE_ELICITATION_ACTION", &action_str);
+    std::env::set_var("CONCLAUDE_ELICITATION_MODE", &mode_str);
+    std::env::set_var(
+        "CONCLAUDE_ELICITATION_ID",
+        payload.elicitation_id.as_deref().unwrap_or(""),
+    );
+
+    let (config, config_path) = get_config().await?;
+    let config_dir = get_config_dir(config_path);
+
+    if !config.elicitation_result.commands.is_empty() {
+        let matching_patterns =
+            match_generic_patterns(&payload.mcp_server_name, &config.elicitation_result.commands)?;
+        if !matching_patterns.is_empty() {
+            let commands = collect_elicitation_result_commands(
+                &config.elicitation_result,
+                &matching_patterns,
+            )?;
+            if !commands.is_empty() {
+                let mut env_vars = HashMap::new();
+                env_vars.insert(
+                    "CONCLAUDE_MCP_SERVER_NAME".to_string(),
+                    payload.mcp_server_name.clone(),
+                );
+                env_vars.insert(
+                    "CONCLAUDE_ELICITATION_ACTION".to_string(),
+                    action_str.clone(),
+                );
+                env_vars.insert("CONCLAUDE_ELICITATION_MODE".to_string(), mode_str.clone());
+                env_vars.insert(
+                    "CONCLAUDE_ELICITATION_ID".to_string(),
+                    payload.elicitation_id.clone().unwrap_or_default(),
+                );
+                insert_base_env_vars(
+                    &mut env_vars,
+                    &payload.base,
+                    &payload,
+                    "ElicitationResult",
+                    config_dir,
+                );
+                let _ = execute_generic_commands(
+                    &commands,
+                    &env_vars,
+                    config_dir,
+                    "ElicitationResult",
+                )
+                .await;
+            }
+        }
+    }
+
+    Ok(HookResult::success())
+}
+
+/// Handles `MessageDisplay` hook events fired as assistant messages stream.
+/// Observational and high-frequency; by default only acts on the final flush.
+///
+/// # Errors
+///
+/// Returns an error if payload reading or validation fails.
+pub async fn handle_message_display() -> Result<HookResult> {
+    let payload: MessageDisplayPayload = read_payload_from_stdin()?;
+    validate_message_display_payload(&payload).map_err(|e| anyhow::anyhow!(e))?;
+
+    let agent_name = std::env::var(AGENT_ENV_VAR).ok();
+    if let Some(ref name) = agent_name {
+        std::env::set_var("CONCLAUDE_AGENT_NAME", name);
+    }
+
+    let (config, config_path) = get_config().await?;
+    let config_dir = get_config_dir(config_path);
+
+    // High-frequency hook: skip command execution unless there is a configured command,
+    // and (by default) only run on the final flush of each message.
+    if !config.message_display.commands.is_empty()
+        && (!config.message_display.only_final || payload.final_flush)
+    {
+        let commands = collect_message_display_commands(&config.message_display)?;
+        if !commands.is_empty() {
+            let mut env_vars = HashMap::new();
+            env_vars.insert("CONCLAUDE_MESSAGE_ID".to_string(), payload.message_id.clone());
+            env_vars.insert("CONCLAUDE_TURN_ID".to_string(), payload.turn_id.clone());
+            env_vars.insert(
+                "CONCLAUDE_MESSAGE_INDEX".to_string(),
+                payload.index.to_string(),
+            );
+            env_vars.insert(
+                "CONCLAUDE_MESSAGE_FINAL".to_string(),
+                payload.final_flush.to_string(),
+            );
+            env_vars.insert("CONCLAUDE_MESSAGE_DELTA".to_string(), payload.delta.clone());
+            insert_base_env_vars(
+                &mut env_vars,
+                &payload.base,
+                &payload,
+                "MessageDisplay",
+                config_dir,
+            );
+            let _ =
+                execute_generic_commands(&commands, &env_vars, config_dir, "MessageDisplay").await;
         }
     }
 

--- a/src/hooks_tests.rs
+++ b/src/hooks_tests.rs
@@ -36,6 +36,10 @@ fn test_is_system_event_hook_new_hooks() {
     assert!(is_system_event_hook("PostToolBatch"));
     assert!(is_system_event_hook("PermissionDenied"));
     assert!(is_system_event_hook("UserPromptExpansion"));
+    assert!(is_system_event_hook("TaskCreated"));
+    assert!(is_system_event_hook("Elicitation"));
+    assert!(is_system_event_hook("ElicitationResult"));
+    assert!(is_system_event_hook("MessageDisplay"));
 
     // PostToolUseFailure is NOT a system event hook
     assert!(!is_system_event_hook("PostToolUseFailure"));

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,12 +8,13 @@ mod types;
 use anyhow::{Context, Result};
 use clap::{Parser, Subcommand};
 use hooks::{
-    handle_config_change, handle_cwd_changed, handle_file_changed, handle_hook_result,
-    handle_instructions_loaded, handle_notification, handle_permission_denied,
-    handle_permission_request, handle_post_compact, handle_post_tool_batch, handle_post_tool_use,
-    handle_post_tool_use_failure, handle_pre_compact, handle_pre_tool_use, handle_session_end,
-    handle_session_start, handle_setup, handle_stop, handle_stop_failure, handle_subagent_start,
-    handle_subagent_stop, handle_task_completed, handle_teammate_idle, handle_user_prompt_expansion,
+    handle_config_change, handle_cwd_changed, handle_elicitation, handle_elicitation_result,
+    handle_file_changed, handle_hook_result, handle_instructions_loaded, handle_message_display,
+    handle_notification, handle_permission_denied, handle_permission_request, handle_post_compact,
+    handle_post_tool_batch, handle_post_tool_use, handle_post_tool_use_failure, handle_pre_compact,
+    handle_pre_tool_use, handle_session_end, handle_session_start, handle_setup, handle_stop,
+    handle_stop_failure, handle_subagent_start, handle_subagent_stop, handle_task_completed,
+    handle_task_created, handle_teammate_idle, handle_user_prompt_expansion,
     handle_user_prompt_submit, handle_worktree_create_result, handle_worktree_remove,
 };
 use std::fs;
@@ -272,6 +273,34 @@ enum HooksCommands {
         #[clap(long)]
         agent: Option<String>,
     },
+    /// Process `TaskCreated` hook - fired when a task is created
+    #[clap(name = "TaskCreated")]
+    TaskCreated {
+        /// Optional agent name for context-aware hook execution
+        #[clap(long)]
+        agent: Option<String>,
+    },
+    /// Process `Elicitation` hook - fired when an MCP server requests user input
+    #[clap(name = "Elicitation")]
+    Elicitation {
+        /// Optional agent name for context-aware hook execution
+        #[clap(long)]
+        agent: Option<String>,
+    },
+    /// Process `ElicitationResult` hook - fired after a user responds to an elicitation
+    #[clap(name = "ElicitationResult")]
+    ElicitationResult {
+        /// Optional agent name for context-aware hook execution
+        #[clap(long)]
+        agent: Option<String>,
+    },
+    /// Process `MessageDisplay` hook - fired as assistant messages stream
+    #[clap(name = "MessageDisplay")]
+    MessageDisplay {
+        /// Optional agent name for context-aware hook execution
+        #[clap(long)]
+        agent: Option<String>,
+    },
 }
 
 #[tokio::main]
@@ -389,6 +418,22 @@ async fn main() -> Result<()> {
             HooksCommands::UserPromptExpansion { agent } => {
                 set_agent_env(agent.as_deref());
                 handle_hook_result(handle_user_prompt_expansion).await
+            }
+            HooksCommands::TaskCreated { agent } => {
+                set_agent_env(agent.as_deref());
+                handle_hook_result(handle_task_created).await
+            }
+            HooksCommands::Elicitation { agent } => {
+                set_agent_env(agent.as_deref());
+                handle_hook_result(handle_elicitation).await
+            }
+            HooksCommands::ElicitationResult { agent } => {
+                set_agent_env(agent.as_deref());
+                handle_hook_result(handle_elicitation_result).await
+            }
+            HooksCommands::MessageDisplay { agent } => {
+                set_agent_env(agent.as_deref());
+                handle_hook_result(handle_message_display).await
             }
         },
         Commands::Visualize { rule, show_matches } => handle_visualize(rule, show_matches).await,
@@ -586,6 +631,10 @@ async fn handle_init(
         "PostToolBatch",
         "PermissionDenied",
         "UserPromptExpansion",
+        "TaskCreated",
+        "Elicitation",
+        "ElicitationResult",
+        "MessageDisplay",
     ];
 
     // Add hook configurations using merge logic to preserve user-defined hooks
@@ -737,6 +786,10 @@ fn generate_agent_hooks(agent_name: &str) -> serde_yaml::Value {
         ("PostToolBatch", false),
         ("PermissionDenied", true), // needs matcher (tool_name)
         ("UserPromptExpansion", true), // needs matcher (command_name)
+        ("TaskCreated", false),
+        ("Elicitation", true), // needs matcher (mcp_server_name)
+        ("ElicitationResult", true), // needs matcher (mcp_server_name)
+        ("MessageDisplay", false),
     ];
 
     let mut hooks_map = Mapping::new();

--- a/src/types.rs
+++ b/src/types.rs
@@ -901,6 +901,168 @@ pub fn validate_user_prompt_expansion_payload(
     Ok(())
 }
 
+/// Payload for `TaskCreated` hook - fired when a task is created.
+/// Mirror of `TaskCompleted`; observational.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TaskCreatedPayload {
+    #[serde(flatten)]
+    pub base: BasePayload,
+    /// Unique identifier for the created task
+    pub task_id: String,
+    /// Subject/title of the created task
+    pub task_subject: String,
+    /// Optional detailed description of the task
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub task_description: Option<String>,
+    /// Optional name of the teammate that owns the task
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub teammate_name: Option<String>,
+    /// Optional name of the team (deprecated upstream; carries the session-derived team name)
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub team_name: Option<String>,
+}
+
+/// Elicitation mode: structured form input or browser-based URL flow.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "lowercase")]
+pub enum ElicitationMode {
+    Form,
+    Url,
+}
+
+impl std::fmt::Display for ElicitationMode {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            ElicitationMode::Form => write!(f, "form"),
+            ElicitationMode::Url => write!(f, "url"),
+        }
+    }
+}
+
+/// Action taken in response to an MCP elicitation.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "lowercase")]
+pub enum ElicitationAction {
+    Accept,
+    Decline,
+    Cancel,
+}
+
+impl std::fmt::Display for ElicitationAction {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            ElicitationAction::Accept => write!(f, "accept"),
+            ElicitationAction::Decline => write!(f, "decline"),
+            ElicitationAction::Cancel => write!(f, "cancel"),
+        }
+    }
+}
+
+/// Payload for `Elicitation` hook - fired when an MCP server requests user input.
+/// Observational.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ElicitationPayload {
+    #[serde(flatten)]
+    pub base: BasePayload,
+    /// Name of the MCP server requesting input
+    pub mcp_server_name: String,
+    /// Message displayed to the user
+    pub message: String,
+    /// Elicitation mode (form or url), when provided
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub mode: Option<ElicitationMode>,
+    /// URL to open (only for url mode)
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub url: Option<String>,
+    /// Identifier correlating url elicitations with completion
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub elicitation_id: Option<String>,
+    /// JSON Schema for the requested input (only for form mode)
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub requested_schema: Option<serde_json::Value>,
+}
+
+/// Payload for `ElicitationResult` hook - fired after a user responds to an MCP elicitation.
+/// Observational.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ElicitationResultPayload {
+    #[serde(flatten)]
+    pub base: BasePayload,
+    /// Name of the MCP server that requested input
+    pub mcp_server_name: String,
+    /// Identifier correlating url elicitations with completion
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub elicitation_id: Option<String>,
+    /// Elicitation mode (form or url), when provided
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub mode: Option<ElicitationMode>,
+    /// The action the user took
+    pub action: ElicitationAction,
+    /// The content the user provided, when applicable
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub content: Option<serde_json::Value>,
+}
+
+/// Payload for `MessageDisplay` hook - fired with each batch of newly completed lines
+/// while an assistant message streams. Display-only / observational.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct MessageDisplayPayload {
+    #[serde(flatten)]
+    pub base: BasePayload,
+    /// UUID of the current turn
+    pub turn_id: String,
+    /// UUID of the assistant message being displayed (stable across flushes)
+    pub message_id: String,
+    /// Zero-based index of this delta within the message
+    pub index: u64,
+    /// True on the message's last flush
+    #[serde(rename = "final")]
+    pub final_flush: bool,
+    /// The newly completed lines since the prior flush
+    pub delta: String,
+}
+
+/// Validates that a `TaskCreatedPayload` contains all required fields.
+pub fn validate_task_created_payload(payload: &TaskCreatedPayload) -> Result<(), String> {
+    validate_base_payload(&payload.base)?;
+    if payload.task_id.trim().is_empty() {
+        return Err("task_id cannot be empty".to_string());
+    }
+    if payload.task_subject.trim().is_empty() {
+        return Err("task_subject cannot be empty".to_string());
+    }
+    Ok(())
+}
+
+/// Validates that an `ElicitationPayload` contains all required fields.
+pub fn validate_elicitation_payload(payload: &ElicitationPayload) -> Result<(), String> {
+    validate_base_payload(&payload.base)?;
+    if payload.mcp_server_name.trim().is_empty() {
+        return Err("mcp_server_name cannot be empty".to_string());
+    }
+    Ok(())
+}
+
+/// Validates that an `ElicitationResultPayload` contains all required fields.
+pub fn validate_elicitation_result_payload(
+    payload: &ElicitationResultPayload,
+) -> Result<(), String> {
+    validate_base_payload(&payload.base)?;
+    if payload.mcp_server_name.trim().is_empty() {
+        return Err("mcp_server_name cannot be empty".to_string());
+    }
+    Ok(())
+}
+
+/// Validates that a `MessageDisplayPayload` contains all required fields.
+pub fn validate_message_display_payload(payload: &MessageDisplayPayload) -> Result<(), String> {
+    validate_base_payload(&payload.base)?;
+    if payload.message_id.trim().is_empty() {
+        return Err("message_id cannot be empty".to_string());
+    }
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1896,5 +2058,119 @@ mod tests {
         let payload: UserPromptExpansionPayload = serde_json::from_str(json).unwrap();
         assert_eq!(payload.expansion_type, ExpansionType::McpPrompt);
         assert_eq!(payload.command_source, Some("my-mcp-server".to_string()));
+    }
+
+    #[test]
+    fn test_task_created_payload_deserialization() {
+        let json = r#"{
+            "session_id": "s",
+            "transcript_path": "/t",
+            "hook_event_name": "TaskCreated",
+            "cwd": "/c",
+            "task_id": "t-1",
+            "task_subject": "Implement feature",
+            "task_description": "details",
+            "teammate_name": "coder"
+        }"#;
+        let payload: TaskCreatedPayload = serde_json::from_str(json).unwrap();
+        assert_eq!(payload.task_id, "t-1");
+        assert_eq!(payload.task_subject, "Implement feature");
+        assert_eq!(payload.task_description, Some("details".to_string()));
+        assert_eq!(payload.teammate_name, Some("coder".to_string()));
+        assert!(validate_task_created_payload(&payload).is_ok());
+
+        let mut empty = payload.clone();
+        empty.task_id = "  ".to_string();
+        assert!(validate_task_created_payload(&empty).is_err());
+    }
+
+    #[test]
+    fn test_elicitation_payload_deserialization() {
+        let json = r#"{
+            "session_id": "s",
+            "transcript_path": "/t",
+            "hook_event_name": "Elicitation",
+            "cwd": "/c",
+            "mcp_server_name": "my-server",
+            "message": "Please authenticate",
+            "mode": "url",
+            "url": "https://example.com/auth",
+            "elicitation_id": "el-1"
+        }"#;
+        let payload: ElicitationPayload = serde_json::from_str(json).unwrap();
+        assert_eq!(payload.mcp_server_name, "my-server");
+        assert_eq!(payload.mode, Some(ElicitationMode::Url));
+        assert_eq!(payload.mode.as_ref().unwrap().to_string(), "url");
+        assert_eq!(payload.url, Some("https://example.com/auth".to_string()));
+        assert_eq!(payload.elicitation_id, Some("el-1".to_string()));
+        assert!(validate_elicitation_payload(&payload).is_ok());
+    }
+
+    #[test]
+    fn test_elicitation_result_payload_deserialization() {
+        let json = r#"{
+            "session_id": "s",
+            "transcript_path": "/t",
+            "hook_event_name": "ElicitationResult",
+            "cwd": "/c",
+            "mcp_server_name": "my-server",
+            "mode": "form",
+            "action": "accept",
+            "content": {"name": "value"}
+        }"#;
+        let payload: ElicitationResultPayload = serde_json::from_str(json).unwrap();
+        assert_eq!(payload.action, ElicitationAction::Accept);
+        assert_eq!(payload.action.to_string(), "accept");
+        assert_eq!(payload.mode, Some(ElicitationMode::Form));
+        assert!(payload.content.is_some());
+        assert!(validate_elicitation_result_payload(&payload).is_ok());
+    }
+
+    #[test]
+    fn test_message_display_payload_deserialization() {
+        let json = r#"{
+            "session_id": "s",
+            "transcript_path": "/t",
+            "hook_event_name": "MessageDisplay",
+            "cwd": "/c",
+            "turn_id": "turn-1",
+            "message_id": "msg-1",
+            "index": 3,
+            "final": true,
+            "delta": "the last line"
+        }"#;
+        let payload: MessageDisplayPayload = serde_json::from_str(json).unwrap();
+        assert_eq!(payload.turn_id, "turn-1");
+        assert_eq!(payload.message_id, "msg-1");
+        assert_eq!(payload.index, 3);
+        assert!(payload.final_flush);
+        assert_eq!(payload.delta, "the last line");
+        assert!(validate_message_display_payload(&payload).is_ok());
+    }
+
+    #[test]
+    fn test_message_display_payload_final_round_trip() {
+        // Ensure the `final` keyword field round-trips through the "final" wire name.
+        let payload = MessageDisplayPayload {
+            base: BasePayload {
+                session_id: "s".to_string(),
+                transcript_path: "/t".to_string(),
+                hook_event_name: "MessageDisplay".to_string(),
+                cwd: "/c".to_string(),
+                permission_mode: None,
+                agent_id: None,
+                agent_type: None,
+                effort: None,
+            },
+            turn_id: "turn-1".to_string(),
+            message_id: "msg-1".to_string(),
+            index: 0,
+            final_flush: false,
+            delta: "partial".to_string(),
+        };
+        let json = serde_json::to_string(&payload).unwrap();
+        assert!(json.contains("\"final\":false"));
+        let back: MessageDisplayPayload = serde_json::from_str(&json).unwrap();
+        assert!(!back.final_flush);
     }
 }


### PR DESCRIPTION
## Summary
Final PR in the sequential series. Completes conclaude's coverage of the Claude Agent SDK `HookEvent` union (now **all 30 events** supported). Adds four more hooks:

| Hook | Config shape | Notes |
|------|--------------|-------|
| `TaskCreated` | keyed by task_subject glob | mirror of `TaskCompleted` |
| `Elicitation` | keyed by mcp_server_name glob | exposes server/message/mode/url/id |
| `ElicitationResult` | keyed by mcp_server_name glob | exposes server/action/mode/id |
| `MessageDisplay` | flat command list, `onlyFinal: true` default | high-frequency stream hook; default runs only on the final flush per message |

All four are **observational**. Adds payload + config types (`ElicitationMode`, `ElicitationAction` enums; the `final` wire field maps to `final_flush` via serde rename), handlers, CLI subcommands, `init`/agent-hook wiring, `is_system_event_hook` registration, regenerated schema + docs, and deserialization/validation/round-trip tests.

## Coverage
With this PR, conclaude handles every event in the SDK `HookEvent` union (30): the original 19 + PostCompact/CwdChanged/FileChanged/InstructionsLoaded (#240) + PostToolBatch/PermissionDenied/UserPromptExpansion (#241) + these 4. `BasePayload` also carries the new `agent_id`/`agent_type`/`effort` attributes and per-hook additions (#239).

## Testing
- `cargo clippy --all-targets --all-features` — clean
- `cargo test` — all pass
- schema/docs regenerate with no diff; docs build — green

🤖 Generated with [Claude Code](https://claude.com/claude-code)