### PR TITLE
fix(stop-gate): regenerate schema/docs via flake cargo binaries, in order

### DIFF
--- a/.conclaude.yaml
+++ b/.conclaude.yaml
@@ -29,16 +29,21 @@ stop:
       showStdout: true
       showStderr: true
       message: "Docs build (cd docs && bun run build) failed - please fix errors"
-    - run: "generate-docs"
+    # Regenerate the config schema, then the docs (generate-docs reads
+    # conclaude-schema.json from disk, so schema MUST run first). Use the repo's
+    # cargo binaries via the flake dev shell -- matching the lint/tests steps --
+    # so output always reflects the current code, instead of any stale,
+    # globally-installed generate-schema/generate-docs binary.
+    - run: "nix develop -c cargo run --quiet --bin generate-schema"
       showStdout: false
       showStderr: false
       showCommand: true
-      message: "Docs build (generate-docs) failed - please fix errors via individual delegation."
-    - run: "generate-schema"
+      message: "Schema generation (cargo run --bin generate-schema) failed - please fix errors via individual delegation."
+    - run: "nix develop -c cargo run --quiet --bin generate-docs"
       showStdout: false
       showStderr: false
       showCommand: true
-      message: "Docs build (generate-schema) failed - please fix errors via individual delegation."
+      message: "Docs generation (cargo run --bin generate-docs) failed - please fix errors via individual delegation."
   # Examples:
   # commands:
   #   - run: "echo 'Starting build...'"


### PR DESCRIPTION
## Problem
The local Stop hook (`.conclaude.yaml` → `stop.commands`) regenerated the schema/docs with bare `generate-schema` / `generate-docs`. Those resolve to **globally-installed binaries** that can be stale, so on every turn-end they overwrote `conclaude-schema.json` with outdated output (observed repeatedly during the hook-support work). Two bugs:

1. **Stale binary** — bare commands ran whatever `generate-schema`/`generate-docs` happened to be on `PATH`, not the repo's current code.
2. **Wrong order** — `generate-docs` ran *before* `generate-schema`, but `src/bin/generate-docs.rs` reads `conclaude-schema.json` from disk, so docs lagged the schema by one run.

## Fix
Run both generators through the flake dev shell's cargo binaries (matching the `nix develop -c lint` / `nix develop -c tests` steps), and reorder schema → docs:

```yaml
- run: "nix develop -c cargo run --quiet --bin generate-schema"
- run: "nix develop -c cargo run --quiet --bin generate-docs"
```

Output now always reflects the current code — the same canonical artifacts CI produces.

## Verification
Verified e2e by a background multi-agent workflow (correctness, functional idempotency in an isolated worktree, repo-wide completeness; findings adversarially confirmed):
- Both commands exit 0 and are **idempotent** — running them on canonical `main` produces zero schema/docs drift.
- No bare `generate-schema`/`generate-docs` invocations remain.
- Config still validates; `.conclaude.yaml` self-protection unchanged.
- No other repo location (CI, flake, scripts, agent frontmatter) invokes the stale generators. (The system-installed stale binaries themselves are out of scope.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated configuration for documentation and schema generation processes to improve build efficiency and reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->